### PR TITLE
Simplify changing script for use with qemux86 target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ of AsteroidOS, it can eventually be merged into the default set of asteroid-laun
 `cd unofficial-watchfaces/`
 - Connect your AsteroidOS Watch, configured to either ADB Mode (ADB transfer) or Developer Mode (SCP transfer) in Settings -> USB.
 - Start `./deploy.sh` to use SCP commands or `./deploy.sh -a` for ADB commands.
+- You can also use `./deploy.sh --help` to get a list of available options.
 - Select a single watchface to deploy to the watch with its given number or copy all available watchfaces at once with option 1.
 - You then can restart the ceres session and apply a single selected watchface with pressing 'y'.
 
@@ -21,10 +22,8 @@ You may [restart the session or reboot the watch](https://asteroidos.org/wiki/us
 
 ### Test watchfaces in qmlscene ###
 
-- After cloning the repo and changing into its local directory like described above, execute test-in-qmlscene.sh without flag to use 24H display.\
-`./test-in-qmlscene.sh`
-- Or with the -use12h flag for 12H display.\
-`./test-in-qmlscene.sh -use12h`
+- After cloning the repo and changing into its local directory like described above, execute `./test-in-qmlscene.sh`.  
+- Options within the GUI allow you to use 24H or 12H, round or square watchface, ambient (darkened) or not, and allows you to take a screenshot.
 
 Note that some community watchfaces use features that are not available in qmlscene, like the battery display.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,81 +1,133 @@
 #!/bin/bash
 # Deploy selected Watchfaces from /unofficial-watchfaces folder
 # to a connected AsteroidOS watch in Developer or ADB mode.
-# Use -a for adb or no flag for scp transfer.
+
+function showHelp {
+    cat << EOF
+./deploy.sh [option]
+Deploy one or more watchfaces to AsteroidOS device.  By default, uses "Developer Mode"
+over ssh, but can also use "ADB Mode" using ADB.
+
+Available options:
+-h or --help    prints this help screen and quits
+-a or --adb     uses ADB command to communicate with watch
+-p or --port    specifies a port to use for ssh and scp commands
+-r or --remote  specifies the remote (watch)  name or address for ssh and scp commands
+-q or --qemu    communicates with QEMU emulated watch (same as -r localhost -p 2222 )
+
+EOF
+}
+
+function pushWatchface {
+    if [ "$ADB" = true ] ; then
+        adb push "$opt"/usr/share/* /usr/share/
+    else
+        scp -P"${WATCHPORT}" -r "$opt"/usr/share/* root@"${WATCHADDR}":/usr/share/
+    fi
+}
+
+function restartCeres {
+    if [ "$ADB" = true ] ; then
+        adb shell systemctl restart user@1000
+    else
+        ssh -p "${WATCHPORT}" root@"${WATCHADDR}" -t "systemctl restart user@1000"
+    fi
+}
+
+function activateWatchface {
+    printf -v cmd %q "file:///usr/share/asteroid-launcher/watchfaces/${opt::-1}.qml"
+    if [ "$ADB" = true ] ; then
+        printf -v cmd %q "dconf write /desktop/asteroid/watchface \'${cmd}\'"
+        adb shell "su ceres -c ${cmd}"
+    else
+        ssh -p "${WATCHPORT}" -t ceres@"${WATCHADDR}" "dconf write /desktop/asteroid/watchface \"'$cmd'\""
+    fi
+}
+
+function showCommsOptions {
+    if [ "$ADB" = true ] ; then
+        echo "Communicating via ADB"
+    else
+        echo "Communicating via ssh to ${WATCHADDR}:${WATCHPORT}"
+    fi
+}
 
 PS3='- Deploy watchface by entering its number - 
 - Refresh list with the enter key -
 - Quit with any other input -'
 
-unset options i
-options[i++]="DEPLOY-ALL"
-while IFS= read -r -d $'\0' f
-  do
-    options[i++]="$f"
-  done < <(find */ -maxdepth 0 -type d -print0 )
+# These are the defaults for SSH access
+WATCHPORT=22
+WATCHADDR=192.168.2.15
+# These are the defaults for local QEMU target
+QEMUPORT=2222
+QEMUADDR=localhost
+# Assume no ADB unless told otherwise
+ADB=false
 
-select opt in "${options[@]}"
-  do
-    if [ "$opt" == "DEPLOY-ALL" ]
-      then
-        for opt in "${options[@]}"
-          do
-            if [ -e $opt/usr/share/ ]
-              then
-              if [ "$1" = "-a" ]
-                then
-                  adb push $opt/usr/share/* /usr/share/
-                else
-                  scp -r $opt/usr/share/* root@192.168.2.15:/usr/share/
-              fi
+options=("DEPLOY-ALL" */)
+
+while [[ $# -gt 0 ]] ; do
+    case $1 in 
+        -a|--adb)
+            ADB=true
+            shift
+            ;;
+        -q|--qemu)
+            WATCHPORT=${QEMUPORT}
+            WATCHADDR=${QEMUADDR}
+            shift
+            ;;
+        -p|--port)
+            WATCHPORT="$2"
+            shift
+            shift
+            ;;
+        -r|--remote)
+            WATCHADDR="$2"
+            shift
+            shift
+            ;;
+        -h|--help)
+            showHelp
+            exit 1
+            ;;
+        *)
+            echo "Ignoring unknown option $1"
+            shift
+            ;;
+    esac
+done 
+
+showCommsOptions
+
+select opt in "${options[@]}" ; do
+    if [ "${opt}" == "DEPLOY-ALL" ] ; then
+        for opt in "${options[@]}" ; do
+            if [ -e "$opt"/usr/share/ ] ; then
+                pushWatchface
             fi
-         done
-         echo " "
-         echo "Press 'y' to restart the ceres session on the watch."
-         echo "Or get back to watchface selection with any other key press."
-         read -rsn1 input
-         if [ "$input" = "y" ];
-           then
-             if [ "$1" = "-a" ]
-               then
-                 adb shell systemctl restart user@1000
-               else
-                 ssh -t root@192.168.2.15 "systemctl restart user@1000"
-             fi
-         fi
-      else
-        if [ -e $opt/usr/share/asteroid-launcher/watchfaces ]
-          then
-            if [ "$1" = "-a" ]
-              then
-                adb push $opt/usr/share/* /usr/share/
-                echo " "
-                echo "Press 'y' to activate ${opt::-1} and restart the ceres session on the watch."
-                echo "Back to watchface selection with any other key press."
-                read -rsn1 input
-                if [ "$input" = "y" ]; 
-                  then
-                    printf -v cmd %q "'file:///usr/share/asteroid-launcher/watchfaces/${opt::-1}.qml'"
-                    printf -v cmd %q "dconf write /desktop/asteroid/watchface $cmd"
-                    adb shell "su ceres -c $cmd"
-                    adb shell systemctl restart user@1000
-                fi
-              else
-                scp -r $opt/usr/share/* root@192.168.2.15:/usr/share/
-                echo " "
-                echo "Press 'y' to activate ${opt::-1} and restart the ceres session on the watch."
-                echo "Back to watchface selection with any other key press."
-                read -rsn1 input
-                if [ "$input" = "y" ]; then
-                  ssh -t ceres@192.168.2.15 "dconf write /desktop/asteroid/watchface \"'file:///usr/share/asteroid-launcher/watchfaces/${opt::-1}.qml'\""
-                  ssh -t root@192.168.2.15 "systemctl restart user@1000"
-                fi
+        done
+        echo " "
+        echo "Press 'y' to restart the ceres session on the watch."
+        echo "Or get back to watchface selection with any other key press."
+        read -rsn1 input
+        if [ "$input" = "y" ] ; then
+            restartCeres
+        fi
+    else
+        if [ -e "$opt"/usr/share/asteroid-launcher/watchfaces ] ; then
+            pushWatchface
+            echo " "
+            echo "Press 'y' to activate ${opt::-1} and restart the ceres session on the watch."
+            echo "Back to watchface selection with any other key press."
+            read -rsn1 input
+            if [ "$input" = "y" ] ; then
+                activateWatchface
+                restartCeres
             fi
-          else
+        else 
             break
         fi
     fi
 done
-
-
-


### PR DESCRIPTION
Using `deploy.sh` with the qemux86 target requires changing the port and address for the `ssh` and `scp` commands.  This simplifies that change by extracting those attributes as shell variables.  The function is unchanged from the original.  Fixes #38.

Signed-off-by: Ed Beroset <beroset@ieee.org>