### PR TITLE
Fix hour hands requestPaint, move to cooperative canvas renderStrategy

### DIFF
--- a/analog-asteroid-logo/usr/share/asteroid-launcher/watchfaces/analog-asteroid-logo.qml
+++ b/analog-asteroid-logo/usr/share/asteroid-launcher/watchfaces/analog-asteroid-logo.qml
@@ -56,6 +56,7 @@ Item {
         id: logoShadowPath
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             prepareContext(ctx)
@@ -108,6 +109,7 @@ Item {
         z: 1
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             prepareContext(ctx)
@@ -143,6 +145,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             prepareContext(ctx)
@@ -193,6 +196,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             prepareContext(ctx)
@@ -240,6 +244,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             prepareContext(ctx)
@@ -263,12 +268,11 @@ Item {
             var minute = wallClock.time.getMinutes()
             var second = wallClock.time.getSeconds()
 
-            if(hourCanvas.hour != hour) {
-                hourCanvas.hour = hour
-                hourCanvas.requestPaint()
-            } if(minuteCanvas.minute != minute) {
+            if(minuteCanvas.minute != minute) {
                 minuteCanvas.minute = minute
                 minuteCanvas.requestPaint()
+                hourCanvas.hour = hour
+                hourCanvas.requestPaint()
             } if(secondCanvas.second != second) {
                 secondCanvas.second = second
                 secondCanvas.requestPaint()

--- a/analog-precision/usr/share/asteroid-launcher/watchfaces/analog-precision.qml
+++ b/analog-precision/usr/share/asteroid-launcher/watchfaces/analog-precision.qml
@@ -53,6 +53,7 @@ Item {
         id: hourHand
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getHours() - 3 + wallClock.time.getMinutes()/60) / 12
@@ -76,6 +77,7 @@ Item {
         id: minuteHand
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -99,6 +101,7 @@ Item {
         id: secondHand
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -137,6 +140,7 @@ Item {
         z: 3
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -154,6 +158,7 @@ Item {
         z: 2
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -176,6 +181,7 @@ Item {
         z: 2
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = 1.5

--- a/analog-railway/usr/share/asteroid-launcher/watchfaces/analog-railway.qml
+++ b/analog-railway/usr/share/asteroid-launcher/watchfaces/analog-railway.qml
@@ -42,6 +42,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -82,6 +83,7 @@ Item {
         property var rotM: (minute - 15)/60
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -115,6 +117,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -160,7 +163,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -181,6 +184,7 @@ Item {
         z: 1
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -202,6 +206,7 @@ Item {
         z: 1
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -223,6 +228,7 @@ Item {
         z: 1
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.width*0.015
@@ -254,7 +260,6 @@ Item {
                 minuteHand.minute = minute
                 hourHand.minute = minute
                 minuteHand.requestPaint()
-            }if(hourHand.hour != hour) {
                 hourHand.hour = hour
                 hourHand.requestPaint()
             }

--- a/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
+++ b/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
@@ -39,7 +39,7 @@ Item {
         id: minuteArc
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getMinutes() -15 )*6
@@ -67,7 +67,7 @@ Item {
         property var minuteY: centerY+Math.sin(rotM * 2 * Math.PI)*width*0.36
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot1 = (0 -15 )*6 * radian
@@ -87,7 +87,7 @@ Item {
         id: hourArc
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = 0.5 * (60 * (wallClock.time.getHours()-3) + wallClock.time.getMinutes())
@@ -115,7 +115,7 @@ Item {
         property var hourY: (centerY+Math.sin(rotH * 2 * Math.PI)*width*0.185)
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot1 = (0 -15 )*6 * radian

--- a/analog-scientific/usr/share/asteroid-launcher/watchfaces/analog-scientific.qml
+++ b/analog-scientific/usr/share/asteroid-launcher/watchfaces/analog-scientific.qml
@@ -40,7 +40,7 @@ Item {
         id: hourStrokes
         z: 3
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -63,7 +63,7 @@ Item {
 
         z: 3
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -93,7 +93,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -125,7 +125,7 @@ Item {
 
         z: 1
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -162,7 +162,7 @@ Item {
 
         z: 2
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -198,6 +198,7 @@ Item {
         z: 4
         visible: !displayAmbient
         anchors.fill: parent
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -240,7 +241,7 @@ Item {
         id: dowCanvas
 
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -271,7 +272,7 @@ Item {
         property bool am: false
 
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -301,7 +302,7 @@ Item {
 
         anchors.fill: parent
         antialiasing: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
 
         onPaint: {
@@ -318,7 +319,7 @@ Item {
         id: monthCanvas
         anchors.fill: parent
         antialiasing: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         property int month: 0
 

--- a/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
+++ b/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
@@ -39,6 +39,7 @@ Item {
         z: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineCap="round"
@@ -61,7 +62,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         property real voffset: -parent.height*0.015
         property real hoffset: -parent.height*0.003
         onPaint: {
@@ -91,6 +92,7 @@ Item {
         property real rotH: (hour-3 + wallClock.time.getMinutes()/60) / 12
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -149,6 +151,7 @@ Item {
         property real rotM: (minute - 15)/60
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -215,6 +218,7 @@ Item {
         property int second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -242,7 +246,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 
@@ -278,7 +282,6 @@ Item {
             }if(minuteHand.minute != minute) {
                 minuteHand.minute = minute
                 minuteHand.requestPaint()
-            }if(hourHand.hour != hour) {
                 hourHand.hour = hour
                 hourHand.requestPaint()
             }if(dateCanvas.date != date) {

--- a/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
+++ b/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
@@ -31,7 +31,7 @@ Item {
         property var centerY: parent.height/2
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getMinutes() -15 )*6
@@ -75,7 +75,7 @@ Item {
         property var minuteY: centerY+Math.sin(rotM * 2 * Math.PI)*height/2.75
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot1 = (0 -15 )*6 *0.01745

--- a/clean-bars/usr/share/asteroid-launcher/watchfaces/clean-bars.qml
+++ b/clean-bars/usr/share/asteroid-launcher/watchfaces/clean-bars.qml
@@ -31,7 +31,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -52,7 +52,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -86,7 +86,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -122,7 +122,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -215,7 +215,6 @@ Item {
             }if(minuteBar.minute !== minute) {
                 minuteBar.minute = minute
                 minuteBar.requestPaint()
-            }if(hourBar.hour !== hour) {
                 hourBar.hour = hour
                 hourBar.requestPaint()
             }

--- a/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
+++ b/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
@@ -35,7 +35,7 @@ Item {
         id: twentyfourhourArc
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot =  0.25 * (60 * (wallClock.time.getHours()+6) + wallClock.time.getMinutes())

--- a/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
+++ b/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
@@ -59,7 +59,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
 
         property var hour: 0
 
@@ -77,7 +77,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
 
         property var minute: 0
 
@@ -97,7 +97,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         property var second: 0
 
@@ -120,7 +120,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
         visible: use12H.value
 
         property var am: false
@@ -144,7 +144,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 
@@ -168,7 +168,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 
@@ -199,12 +199,11 @@ Item {
                 hour = hour % 12
                 if (hour == 0) hour = 12;
             }
-            if(hourCanvas.hour != hour) {
-                hourCanvas.hour = hour
-                hourCanvas.requestPaint()
-            } if(minuteCanvas.minute != minute) {
+            if(minuteCanvas.minute != minute) {
                 minuteCanvas.minute = minute
                 minuteCanvas.requestPaint()
+                hourCanvas.hour = hour
+                hourCanvas.requestPaint()
             } if(secondCanvas.second != second) {
                 secondCanvas.second = second
                 secondCanvas.requestPaint()

--- a/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
+++ b/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
@@ -60,7 +60,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
 
         property var hour: 0
         property var minute: 0
@@ -82,8 +82,9 @@ Item {
     Canvas {
         id: amPmCanvas
         anchors.fill: parent
-        renderTarget: Canvas.FramebufferObject
-        property var am: false
+        renderStrategy: Canvas.Cooperative
+
+        property bool am: false
 
         onPaint: {
             var ctx = getContext("2d")
@@ -111,7 +112,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject 
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 

--- a/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
+++ b/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
@@ -29,6 +29,7 @@ Item {
         z: 3
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.height/48
@@ -55,6 +56,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()

--- a/motivational-quotes/usr/share/asteroid-launcher/watchfaces/motivational-quotes.qml
+++ b/motivational-quotes/usr/share/asteroid-launcher/watchfaces/motivational-quotes.qml
@@ -197,6 +197,7 @@ Item {
         property var rotH: (wallClock.time.getHours()-3 + wallClock.time.getMinutes()/60) / 12
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -236,6 +237,7 @@ Item {
         property var rotM: (wallClock.time.getMinutes() - 15)/60
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -274,7 +276,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         property var voffset: -parent.height*0.017
         onPaint: {
             var ctx = getContext("2d")

--- a/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
+++ b/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
@@ -32,7 +32,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getSeconds() - 15)*6
@@ -61,7 +61,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getMinutes() -15 )*6
@@ -96,7 +96,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = 0.5 * (60 * (wallClock.time.getHours()-3) + wallClock.time.getMinutes())
@@ -226,7 +226,6 @@ Item {
             }if(minuteCanvas.minute != minute) {
                 minuteCanvas.minute = minute
                 minuteCanvas.requestPaint()
-            } if(hourCanvas.hour != hour) {
                 hourCanvas.hour = hour
                 hourCanvas.requestPaint()
             }

--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -32,7 +32,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var date = wallClock.time.getDate()

--- a/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
+++ b/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
@@ -30,7 +30,7 @@ Item {
         id: rainbow
         anchors.fill: parent
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -83,7 +83,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -108,7 +108,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -133,7 +133,7 @@ Item {
         anchors.fill: parent
         anchors.bottom: parent.bottom
         smooth: true
-        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -219,7 +219,6 @@ Item {
             }if(minuteBar.minute != minute) {
                 minuteBar.minute = minute
                 minuteBar.requestPaint()
-            }if(hourBar.hour != hour) {
                 hourBar.hour = hour
                 hourBar.requestPaint()
             }
@@ -236,6 +235,5 @@ Item {
         minuteBar.requestPaint()
         hourBar.hour = hour
         hourBar.requestPaint()
-
     }
 }

--- a/sporty-round-v2/usr/share/asteroid-launcher/watchfaces/sporty-round-v2.qml
+++ b/sporty-round-v2/usr/share/asteroid-launcher/watchfaces/sporty-round-v2.qml
@@ -33,6 +33,7 @@ Item {
         id: hourArc
         property var hour: 0
         anchors.fill: parent
+        renderStrategy: Canvas.Cooperative
         smooth: true
         onPaint: {
             var ctx = getContext("2d")
@@ -108,6 +109,7 @@ Item {
         z: 2
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -133,6 +135,7 @@ Item {
         z: 2
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.height*0.008
@@ -154,6 +157,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -181,6 +185,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -208,6 +213,7 @@ Item {
         z: 4
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.height/32
@@ -229,6 +235,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -256,6 +263,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -284,6 +292,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -405,7 +414,6 @@ Item {
                 minuteHand.requestPaint()
                 minuteDisplay.minute = minute
                 minuteDisplay.requestPaint()
-            }if(hourArc.hour !== hour) {
                 hourArc.hour = hour
                 hourArc.requestPaint()
             }

--- a/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
+++ b/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
@@ -30,6 +30,7 @@ Item {
         z: 1
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -47,6 +48,7 @@ Item {
         z: 2
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.height/200
@@ -72,6 +74,7 @@ Item {
         id: secondDisplay
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -100,6 +103,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -123,6 +127,7 @@ Item {
         z: 3
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.height/32
@@ -145,6 +150,7 @@ Item {
         id: minuteDisplay
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -172,6 +178,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -197,6 +204,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot = 0.5 * (60 * (hour-3) + wallClock.time.getMinutes())
@@ -282,7 +290,6 @@ Item {
                 minuteHand.minute = minute
                 minuteHand.requestPaint()
                 minuteDisplay.requestPaint()
-            }if(hourArc.hour !== hour) {
                 hourArc.hour = hour
                 hourArc.requestPaint()
             }


### PR DESCRIPTION
### Move to `renderStrategy: Canvas.Cooperative` to reduce user perceived lag.
As also proposed for the stock watchfaces https://github.com/AsteroidOS/asteroid-launcher/pull/76/commits/515ca01da43ce7d996058cc9491be0507511c01a 
Solves this issue for all canvas watchfaces https://github.com/AsteroidOS/meta-sparrow-hybris/issues/14
Tested them all on sparrow with `renderStrategy: Canvas.Cooperative` applied to all canvases and the graphic glitch is gone.

### Correct hour hands not updating bug for remaining watchfaces
 https://github.com/AsteroidOS/unofficial-watchfaces/issues/48

