### PR TITLE
Fix battery display on unofficial watchfaces.

### DIFF
--- a/analog-goldie/usr/share/asteroid-launcher/watchfaces/analog-goldie.qml
+++ b/analog-goldie/usr/share/asteroid-launcher/watchfaces/analog-goldie.qml
@@ -24,7 +24,7 @@
 
 import QtQuick 2.15
 import QtGraphicalEffects 1.15
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -39,12 +39,8 @@ Item {
 
     anchors.fill: parent
 
-    ContextProperty {
-            id: batteryChargePercentage
-
-            key: "Battery.ChargePercentage"
-            value: "100"
-            Component.onCompleted: batteryChargePercentage.subscribe()
+    MceBatteryLevel {
+        id: batteryChargePercentage
     }
 
     Image {
@@ -370,7 +366,7 @@ Item {
         Item {
             id: batteryBox
 
-            property int value: batteryChargePercentage.value
+            property int value: batteryChargePercentage.percent
 
             onValueChanged: batteryArc.requestPaint()
 
@@ -406,14 +402,14 @@ Item {
                     ctx.closePath()
                     ctx.lineWidth = root.height * .005
                     ctx.lineCap="round"
-                    ctx.strokeStyle = batteryChargePercentage.value < 30 ?
+                    ctx.strokeStyle = batteryChargePercentage.percent < 30 ?
                                 accColor : "#44BBA4"
                     ctx.beginPath()
                     ctx.arc(parent.width / 2,
                             parent.height / 2,
                             parent.width * .456,
                             270 * rad,
-                            ((batteryChargePercentage.value / 100 * 360) + 270) * rad,
+                            ((batteryChargePercentage.percent / 100 * 360) + 270) * rad,
                             false
                             );
                     ctx.stroke()
@@ -433,7 +429,7 @@ Item {
                     styleName:"Condensed Light"
                 }
                 color: highColor
-                text: batteryChargePercentage.value
+                text: batteryChargePercentage.percent
 
                 Text {
                      id: batteryPercent

--- a/analog-scientific-v2/usr/share/asteroid-launcher/watchfaces/analog-scientific-v2.qml
+++ b/analog-scientific-v2/usr/share/asteroid-launcher/watchfaces/analog-scientific-v2.qml
@@ -23,7 +23,7 @@
 
 import QtQuick 2.1
 import QtGraphicalEffects 1.15
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -32,11 +32,8 @@ Item {
     property string imgPath: "../watchfaces-img/analog-scientific-v2-"
     property real rad: 0.01745
 
-    ContextProperty {
+    MceBatteryLevel {
         id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
     }
 
     Repeater {
@@ -377,7 +374,7 @@ Item {
 
     Item {
         id: batteryBox
-        property int value: batteryChargePercentage.value
+        property int value: batteryChargePercentage.percent
         onValueChanged: batteryArc.requestPaint()
         anchors {
             centerIn: parent
@@ -417,16 +414,16 @@ Item {
                                                          parent.width * 0.46
                                                          )
                 gradient.addColorStop(0.44,
-                                      batteryChargePercentage.value < 30 ?
+                                      batteryChargePercentage.percent < 30 ?
                                           "#00EF476F" :
-                                          batteryChargePercentage.value < 60 ?
+                                          batteryChargePercentage.percent < 60 ?
                                               "#00D0E562" :
                                               "#0023F0C7"
                                       )
                 gradient.addColorStop(0.97,
-                                      batteryChargePercentage.value < 30 ?
+                                      batteryChargePercentage.percent < 30 ?
                                           "#ffEF476F" :
-                                          batteryChargePercentage.value < 60 ?
+                                          batteryChargePercentage.percent < 60 ?
                                               "#ffD0E562" :
                                               "#ff23F0C7"
                                       )
@@ -438,7 +435,7 @@ Item {
                         parent.height / 2,
                         parent.width * 0.456,
                         270 * rad,
-                        ((batteryChargePercentage.value/100*360)+270) * rad,
+                        ((batteryChargePercentage.percent/100*360)+270) * rad,
                         false
                         );
                 ctx.lineTo(parent.width / 2,
@@ -459,7 +456,7 @@ Item {
             font.family: "Outfit"
             font.styleName:"Thin"
             color: "#ffffffff"
-            text: batteryChargePercentage.value
+            text: batteryChargePercentage.percent
 
             Text {
                  z: 9

--- a/arc/usr/share/asteroid-launcher/watchfaces/Arc.qml
+++ b/arc/usr/share/asteroid-launcher/watchfaces/Arc.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.1
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.utils 1.0
 
 Item {
@@ -102,12 +102,12 @@ Item {
                             color: watchFace.arccolor
                         }
                         GradientStop {
-                            position: Math.max(0.01, (batteryChargePercentage.value/100) - 0.011)
+                            position: Math.max(0.01, (batteryChargePercentage.percent/100) - 0.011)
                             color: watchFace.arccolor
                         }
                         GradientStop {
                             id: batteryGradientStop
-                            position: Math.min(0.99, (batteryChargePercentage.value/100) + 0.011)
+                            position: Math.min(0.99, (batteryChargePercentage.percent/100) + 0.011)
                             color: watchFace.arcbatterylowcolor
                         }
                         GradientStop {
@@ -354,17 +354,9 @@ Item {
         }
 
     }
-    ContextProperty {
-        id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
-    }
 
-    ContextProperty {
-        id: batteryIsCharging
-        key: "Battery.IsCharging"
-        value: false
+    MceBatteryLevel {
+        id: batteryChargePercentage
     }
 
 }

--- a/karlos-matrix/usr/share/asteroid-launcher/watchfaces/karlos-matrix.qml
+++ b/karlos-matrix/usr/share/asteroid-launcher/watchfaces/karlos-matrix.qml
@@ -22,7 +22,7 @@
  */
 
 import QtQuick 2.1
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -137,8 +137,8 @@ Item {
             //topMargin: -parent.height*0.03
             horizontalCenter: parent.horizontalCenter
         }
-        color: batteryChargePercentage.value < 30 ? 'red': batteryChargePercentage.value < 60 ? 'yellow': Qt.rgba(0, 1, 0, 1)
-        width: parent.width/100*batteryChargePercentage.value
+        color: batteryChargePercentage.percent < 30 ? 'red': batteryChargePercentage.percent < 60 ? 'yellow': Qt.rgba(0, 1, 0, 1)
+        width: parent.width/100*batteryChargePercentage.percent
         height: parent.height * 0.004
     }
 
@@ -147,20 +147,17 @@ Item {
         id: batteryDisplay
         font.pixelSize: parent.height*0.05
         font.family: "Elektra"
-        color: batteryChargePercentage.value < 30 ? 'red': batteryChargePercentage.value < 60 ? 'yellow': Qt.rgba(0, 1, 0, 1)
+        color: batteryChargePercentage.percent < 30 ? 'red': batteryChargePercentage.percent < 60 ? 'yellow': Qt.rgba(0, 1, 0, 1)
         horizontalAlignment: Text.AlignHCenter
         anchors {
             top: batteryBack.bottom
             topMargin: -parent.height*0.0055
             horizontalCenter: parent.horizontalCenter
         }
-        text: batteryChargePercentage.value
+        text: batteryChargePercentage.percent
     }
 
-    ContextProperty {
+    MceBatteryLevel {
         id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
     }
 }

--- a/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
+++ b/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
@@ -14,7 +14,7 @@
  */
 
 import QtQuick 2.1
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 import Nemo.Ngf 1.0
@@ -23,12 +23,6 @@ Item {
     id: watchFace
     property var time: wallClock.time //new Date() //
     property string imgPath: "../watchfaces-img/"
-
-    function formatAll(){
-        secondsDisplay.format()
-        dateDisplay.text = Qt.binding(function() { return watchFace.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM") })
-        timeDisplay.format()
-    }
 
     FontLoader { id: localFont
         name:'Digital-7 Mono'
@@ -79,10 +73,10 @@ Item {
                 style: Text.Outline; styleColor: Qt.rgba(255,255,255,0.5)
                 opacity: 0.9
                 horizontalAlignment: Text.AlignHCenter
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + wallClock.time.toLocaleString(Qt.locale(), ":mm")}
+                text: if (use12H.value)
+                          wallClock.time.toLocaleString(Qt.locale(), "hh:mm ap").slice(0, 5)
                       else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH") + wallClock.time.toLocaleString(Qt.locale(), ":mm")
+                          wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
 
             }
 
@@ -91,19 +85,11 @@ Item {
                 anchors.topMargin: parent.width * 0.01
                 anchors.right: parent.right
                 anchors.top: parent.top
-                text: '00'
+                text: wallClock.time.toLocaleString(Qt.locale(), "ss")
                 font { family: localFont.name; pixelSize:timeDisplay.font.pixelSize * 0.5; capitalization: Font.Capitalize }
                 color: timeDisplay.color
                 style: timeDisplay.style
                 styleColor: timeDisplay.styleColor
-                Component.onCompleted: format()
-                function format(){
-                    var sec = watchFace.time.getSeconds();
-                    if (sec < 10) {
-                        sec = "0" + sec;
-                    }
-                    text = sec
-                }
             }
         }
 
@@ -116,11 +102,11 @@ Item {
         width: parent.width * 0.289
         height: parent.width  * 0.115
         Rectangle {
-            color: batteryChargePercentage.value < 50 ? 'red': 'green'
+            color: batteryChargePercentage.percent < 50 ? 'red': 'green'
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.bottom: parent.bottom
-            width: batteryChargePercentage.value * parent.width/100
+            width: batteryChargePercentage.percent * parent.width/100
             opacity: 0.5
         }
         Icon {
@@ -132,7 +118,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             opacity: 0.4
             rotation: 270
-            visible: batteryIsCharging.value
+            visible: batteryChargeState.value == MceBatteryState.Charging
         }
     }
 
@@ -145,7 +131,7 @@ Item {
         sourceSize.height: parent.width
         sourceSize.width: parent.width
         fillMode: Image.PreserveAspectFit
-        source: "./kitt-compass.svg"
+        source: "kitt-compass.svg"
     }
 
     Image {
@@ -188,24 +174,12 @@ Item {
         id: btStatus
     }
 
-    ContextProperty {
+    MceBatteryLevel {
         id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
     }
 
-    ContextProperty {
-        id: batteryIsCharging
-        key: "Battery.IsCharging"
-        value: false
-    }
+    MceBatteryState {
+        id: batteryChargeState
+    } 
 
-    Connections {
-        target: wallClock
-        onTimeChanged: {
-            formatAll()
-        }
-    }
-    Component.onCompleted: formatAll()
 }

--- a/sporty-round-v2/usr/share/asteroid-launcher/watchfaces/sporty-round-v2.qml
+++ b/sporty-round-v2/usr/share/asteroid-launcher/watchfaces/sporty-round-v2.qml
@@ -22,7 +22,7 @@
  */
 
 import QtQuick 2.1
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -301,13 +301,13 @@ Item {
             ctx.shadowOffsetY = 0
             ctx.shadowBlur = 2
             var gradient = ctx.createRadialGradient (parent.width/2, parent.height/2, 0, parent.width/2, parent.height/2, parent.width *0.46)
-            gradient.addColorStop(0.39, batteryChargePercentage.value < 30 ? 'red': Qt.rgba(0.318, 1, 0.051, 0.0))
-            gradient.addColorStop(0.95, batteryChargePercentage.value < 30 ? 'red': Qt.rgba(0.318, 1, 0.051, 0.9))
+            gradient.addColorStop(0.39, batteryChargePercentage.percent < 30 ? 'red': Qt.rgba(0.318, 1, 0.051, 0.0))
+            gradient.addColorStop(0.95, batteryChargePercentage.percent < 30 ? 'red': Qt.rgba(0.318, 1, 0.051, 0.9))
             ctx.lineWidth = parent.height*0.007
             ctx.lineCap="round"
             ctx.strokeStyle = gradient
             ctx.beginPath()
-            ctx.arc(parent.width/2, parent.height/2, parent.width *0.46, 270* 0.01745, ((batteryChargePercentage.value/100*360)+270)* 0.01745, false);
+            ctx.arc(parent.width/2, parent.height/2, parent.width *0.46, 270* 0.01745, ((batteryChargePercentage.percent/100*360)+270)* 0.01745, false);
             ctx.lineTo(parent.width/2,
                        parent.height/2)
             ctx.stroke()
@@ -319,7 +319,7 @@ Item {
         z: 9
         id: batteryDisplay
         renderType: Text.NativeRendering
-        property var rotB: (batteryChargePercentage.value-25)/100
+        property var rotB: (batteryChargePercentage.percent-25)/100
         property var centerX: parent.width/2-width/2
         property var centerY: parent.height/2-height/2
         font.pixelSize: parent.height/16
@@ -330,7 +330,7 @@ Item {
         style: Text.Outline; styleColor: "#80000000"
         x: centerX+Math.cos(rotB * 2 * Math.PI)*height*4.5
         y: centerY+Math.sin(rotB * 2 * Math.PI)*height*4.5
-        text: "<b>" + batteryChargePercentage.value + "</b>"
+        text: "<b>" + batteryChargePercentage.percent + "</b>"
     }
 
     Text {
@@ -388,11 +388,8 @@ Item {
         text: wallClock.time.toLocaleString(Qt.locale(), "dd MMMM")
     }
 
-    ContextProperty {
+    MceBatteryLevel {
         id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
     }
 
     Connections {


### PR DESCRIPTION
Several of the unofficial watchfaces relied on org.freedesktop.context
for the battery charge level.  We now use Nemo.Mce to get that value, so
this change fixes four of the six affected watchfaces.

Signed-off-by: Ed Beroset <beroset@ieee.org>