### PR TITLE
Add non-square option to tester

### DIFF
--- a/loader.qml
+++ b/loader.qml
@@ -24,7 +24,7 @@ ApplicationWindow {
         }
 
         height: halfSize.checked ? 320 : 640
-        width: halfSize.checked ? 320 : 640
+        width: nonSquare.checked ? height * 0.85 : height
 
         Rectangle {
             id: frame
@@ -189,6 +189,17 @@ ApplicationWindow {
                         ToolTip.visible: hovered
                         ToolTip.delay: 600
                         ToolTip.text: qsTr("Show the watchface as it would look on a round watch")
+                        checked: true
+                    }
+
+                    CheckBox {
+                        id: nonSquare
+
+                        font.pixelSize: 30
+                        text: "\u25AF"
+                        ToolTip.visible: hovered
+                        ToolTip.delay: 600
+                        ToolTip.text: qsTr("Show the watchface as it would look on a non-square watch")
                         checked: true
                     }
 


### PR DESCRIPTION
This adds the option to display the watchface as non-square with a fixed
ratio 85% width to height to match the Oppo watch.