### PR TITLE
Make qmlscene preview generation consistent

### DIFF
--- a/loader.qml
+++ b/loader.qml
@@ -139,19 +139,19 @@ ApplicationWindow {
                         }
 
                         if (sequencer === 2) {
-                            background.source = "background-round.jpg";
-                            watchfaceDisplayFrame.snapshot("-round.png");
-                        }
-
-                        if (sequencer === 3) {
                             background.source = "background.jpg";
                             roundCheckBox.checked = false;
                             watchfaceDisplayFrame.snapshot(".png");
                         }
+                        
+                        if (sequencer === 3) {
+                            background.source = "background-round.jpg";
+                            roundCheckBox.checked = true;
+                            watchfaceDisplayFrame.snapshot("-round.png");
+                        }
 
                         if (sequencer === 4) {
                             frame.color = "black";
-                            roundCheckBox.checked = true;
                             sequencer = 0;
                             snapshotsTimer.running = false;
                         }

--- a/loader.qml
+++ b/loader.qml
@@ -131,25 +131,25 @@ ApplicationWindow {
                     property real sequencer: 0
 
                     function transSnapshots() {
-                        if (sequencer === 0) {
+                        if (sequencer === 1) {
                             watchfaceDisplayFrame.color = "transparent";
                             background.source = "";
                             frame.color = "transparent";
                             watchfaceDisplayFrame.snapshot("-trans.png");
                         }
 
-                        if (sequencer === 1) {
+                        if (sequencer === 2) {
                             background.source = "background-round.jpg";
                             watchfaceDisplayFrame.snapshot("-round.png");
                         }
 
-                        if (sequencer === 2) {
+                        if (sequencer === 3) {
                             background.source = "background.jpg";
                             roundCheckBox.checked = false;
                             watchfaceDisplayFrame.snapshot(".png");
                         }
 
-                        if (sequencer === 3) {
+                        if (sequencer === 4) {
                             frame.color = "black";
                             roundCheckBox.checked = true;
                             sequencer = 0;
@@ -161,8 +161,8 @@ ApplicationWindow {
                         id: snapshotsTimer
                         interval: 500; running: false; repeat: true
                         onTriggered: {
-                            previewButton.transSnapshots()
                             previewButton.sequencer++
+                            previewButton.transSnapshots()
                         }
                     }
 


### PR DESCRIPTION
Previously, the transparent snapshot would never be updated after the first time. Now it will always generate a new one.

It was also previously assumed when generating that the round option was already enabled. Now it will ensure it is off when capturing the square image, and on when capturing the round image.