### PR TITLE
Make qmlscene horizontal + generate preview fixes

### DIFF
--- a/loader.qml
+++ b/loader.qml
@@ -15,6 +15,7 @@ ApplicationWindow {
     minimumHeight: 640
 
     RowLayout {
+        spacing: 0
         ToolBar {
             id: controls
             Layout.fillHeight: true

--- a/loader.qml
+++ b/loader.qml
@@ -139,19 +139,19 @@ ApplicationWindow {
                         }
 
                         if (sequencer === 2) {
-                            background.source = "background-round.jpg";
-                            watchfaceDisplayFrame.snapshot("-round.png");
-                        }
-
-                        if (sequencer === 3) {
                             background.source = "background.jpg";
                             roundCheckBox.checked = false;
                             watchfaceDisplayFrame.snapshot(".png");
                         }
+                        
+                        if (sequencer === 3) {
+                            background.source = "background-round.jpg";
+                            roundCheckBox.checked = true;
+                            watchfaceDisplayFrame.snapshot("-round.png");
+                        }
 
                         if (sequencer === 4) {
                             frame.color = "black";
-                            roundCheckBox.checked = true;
                             sequencer = 0;
                             snapshotsTimer.running = false;
                         }

--- a/loader.qml
+++ b/loader.qml
@@ -16,6 +16,12 @@ ApplicationWindow {
 
     RowLayout {
         ToolBar {
+            id: controls
+            Layout.fillHeight: true
+            padding: 5
+            background: Rectangle {
+                color: "lightblue"
+            }
             ColumnLayout {
                 RowLayout {
                     Layout.alignment: Qt.AlignCenter
@@ -305,12 +311,6 @@ ApplicationWindow {
                         text: featureSlider.value.toFixed(3)
                     }
                 }
-            }
-
-            id: controls
-            Layout.fillHeight: true
-            background: Rectangle {
-                color: "lightblue"
             }
         }
 

--- a/loader.qml
+++ b/loader.qml
@@ -97,10 +97,10 @@ ApplicationWindow {
                     }
                 }
 
-                RowLayout {
+                ColumnLayout {
                     Layout.alignment: Qt.AlignCenter
 
-                    ColumnLayout {
+                    RowLayout {
                         Layout.alignment: Qt.AlignCenter
 
                         CheckBox {
@@ -144,7 +144,7 @@ ApplicationWindow {
                         }
                     }
 
-                    ColumnLayout {
+                    RowLayout {
                         Layout.alignment: Qt.AlignCenter
 
                         CheckBox {
@@ -167,99 +167,103 @@ ApplicationWindow {
                         }
                     }
 
-                    Frame {
-                        padding: 0
+                    RowLayout {
+                        Layout.alignment: Qt.AlignHCenter
+                        Frame {
+                            padding: 0
 
-                        Row {
-                            Tumbler {
-                                id: monthsTumbler
+                            Row {
+                                Tumbler {
+                                    id: monthsTumbler
 
-                                enabled: setStaticTimeCheckBox.checked
-                                currentIndex: appRoot.initialStaticTime.getMonth()
-                                model: 12
+                                    enabled: setStaticTimeCheckBox.checked
+                                    currentIndex: appRoot.initialStaticTime.getMonth()
+                                    model: 12
 
-                                WheelHandler {
-                                    property: "currentIndex"
-                                    rotationScale: appRoot.mouseWheelScale
+                                    WheelHandler {
+                                        property: "currentIndex"
+                                        rotationScale: appRoot.mouseWheelScale
+                                    }
+
+                                    delegate: Label {
+                                        text: appRoot.locale.standaloneMonthName(index, Locale.ShortFormat)
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
                                 }
 
-                                delegate: Label {
-                                    text: appRoot.locale.standaloneMonthName(index, Locale.ShortFormat)
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
+                                Tumbler {
+                                    id: daysTumbler
+
+                                    enabled: setStaticTimeCheckBox.checked
+                                    currentIndex: appRoot.initialStaticTime.getDate() - 1
+                                    model: 31
+
+                                    WheelHandler {
+                                        property: "currentIndex"
+                                        rotationScale: appRoot.mouseWheelScale
+                                    }
+
+                                    delegate: Label {
+                                        text: index + 1
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
                                 }
                             }
+                        }
 
-                            Tumbler {
-                                id: daysTumbler
+                        Frame {
+                            padding: 0
 
-                                enabled: setStaticTimeCheckBox.checked
-                                currentIndex: appRoot.initialStaticTime.getDate() - 1
-                                model: 31
+                            Row {
+                                Tumbler {
+                                    id: hoursTumbler
 
-                                WheelHandler {
-                                    property: "currentIndex"
-                                    rotationScale: appRoot.mouseWheelScale
+                                    enabled: setStaticTimeCheckBox.checked
+                                    currentIndex: appRoot.initialStaticTime.getHours()
+                                    model: 24
+
+                                    WheelHandler {
+                                        property: "currentIndex"
+                                        rotationScale: appRoot.mouseWheelScale
+                                    }
                                 }
 
-                                delegate: Label {
-                                    text: index + 1
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
+                                Tumbler {
+                                    id: minutesTumbler
+
+                                    enabled: setStaticTimeCheckBox.checked
+                                    currentIndex: appRoot.initialStaticTime.getMinutes()
+                                    model: 60
+
+                                    WheelHandler {
+                                        property: "currentIndex"
+                                        rotationScale: appRoot.mouseWheelScale
+                                    }
+                                }
+
+                                Tumbler {
+                                    id: secondsTumbler
+
+                                    enabled: setStaticTimeCheckBox.checked
+                                    currentIndex: appRoot.initialStaticTime.getSeconds()
+                                    model: 60
+
+                                    WheelHandler {
+                                        property: "currentIndex"
+                                        rotationScale: appRoot.mouseWheelScale
+                                    }
                                 }
                             }
                         }
                     }
 
-                    Frame {
-                        padding: 0
-
-                        Row {
-                            Tumbler {
-                                id: hoursTumbler
-
-                                enabled: setStaticTimeCheckBox.checked
-                                currentIndex: appRoot.initialStaticTime.getHours()
-                                model: 24
-
-                                WheelHandler {
-                                    property: "currentIndex"
-                                    rotationScale: appRoot.mouseWheelScale
-                                }
-                            }
-
-                            Tumbler {
-                                id: minutesTumbler
-
-                                enabled: setStaticTimeCheckBox.checked
-                                currentIndex: appRoot.initialStaticTime.getMinutes()
-                                model: 60
-
-                                WheelHandler {
-                                    property: "currentIndex"
-                                    rotationScale: appRoot.mouseWheelScale
-                                }
-                            }
-
-                            Tumbler {
-                                id: secondsTumbler
-
-                                enabled: setStaticTimeCheckBox.checked
-                                currentIndex: appRoot.initialStaticTime.getSeconds()
-                                model: 60
-
-                                WheelHandler {
-                                    property: "currentIndex"
-                                    rotationScale: appRoot.mouseWheelScale
-                                }
-                            }
-                        }
-                    }
                 }
 
                 RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
                     Text {
-                        leftPadding: 100
                         text: qsTr("featureSlider")
                     }
 

--- a/loader.qml
+++ b/loader.qml
@@ -14,85 +14,6 @@ ApplicationWindow {
     minimumWidth: 640
     minimumHeight: 640 + header.height
 
-    Rectangle {
-        id: watchfaceDisplayFrame
-
-        function snapshot(suffix) {
-            watchfaceDisplayFrame.grabToImage(function(result) {
-                result.saveToFile(appRoot.nameOfWatchfaceToBeTested + suffix);
-            }, Qt.size(640, 640));
-        }
-
-        height: halfSize.checked ? 320 : 640
-        width: nonSquare.checked ? height * 0.85 : height
-
-        Rectangle {
-            id: frame
-
-            anchors.fill: parent
-            color: "black"
-            focus: true
-            layer.enabled: roundCheckBox.checked
-            Keys.onReturnPressed: watchfaceDisplayFrame.snapshot()
-
-            Image {
-                id: background
-
-                visible: !appRoot.displayAmbient
-                source: "background.jpg"
-                anchors.fill: parent
-            }
-
-            Loader {
-                id: watchfaceLoader
-
-                anchors.fill: parent
-                source: appRoot.nameOfWatchfaceToBeTested 
-                        + "/usr/share/asteroid-launcher/watchfaces/" 
-                        + appRoot.nameOfWatchfaceToBeTested + ".qml"
-            }
-
-            layer.effect: OpacityMask {
-                anchors.fill: parent
-                source: frame
-
-                maskSource: Rectangle {
-                    width: frame.width
-                    height: frame.height
-                    radius: frame.width / 2
-                }
-            }
-        }
-
-        Item {
-            id: use12H
-
-            property bool value: twelveHourCheckBox.checked
-        }
-
-        Item {
-            id: wallClock
-
-            property var time: getDisplayTime()
-
-            function getDisplayTime(statictime) {
-                var displayTime = new Date();
-                if (setStaticTimeCheckBox.checked) {
-                    displayTime.setHours(hoursTumbler.currentIndex, minutesTumbler.currentIndex, secondsTumbler.currentIndex);
-                    displayTime.setMonth(monthsTumbler.currentIndex, daysTumbler.currentIndex + 1);
-                }
-                return displayTime;
-            }
-
-            Timer {
-                interval: 1000
-                running: true
-                repeat: true
-                onTriggered: wallClock.time = wallClock.getDisplayTime()
-            }
-        }
-    }
-
     header: ToolBar {
         ColumnLayout {
             RowLayout {
@@ -143,7 +64,7 @@ ApplicationWindow {
                             roundCheckBox.checked = false;
                             watchfaceDisplayFrame.snapshot(".png");
                         }
-                        
+
                         if (sequencer === 3) {
                             background.source = "background-round.jpg";
                             roundCheckBox.checked = true;
@@ -384,6 +305,85 @@ ApplicationWindow {
 
         background: Rectangle {
             color: "lightblue"
+        }
+    }
+
+    Rectangle {
+        id: watchfaceDisplayFrame
+
+        function snapshot(suffix) {
+            watchfaceDisplayFrame.grabToImage(function(result) {
+                result.saveToFile(appRoot.nameOfWatchfaceToBeTested + suffix);
+            }, Qt.size(640, 640));
+        }
+
+        height: halfSize.checked ? 320 : 640
+        width: nonSquare.checked ? height * 0.85 : height
+
+        Rectangle {
+            id: frame
+
+            anchors.fill: parent
+            color: "black"
+            focus: true
+            layer.enabled: roundCheckBox.checked
+            Keys.onReturnPressed: watchfaceDisplayFrame.snapshot()
+
+            Image {
+                id: background
+
+                visible: !appRoot.displayAmbient
+                source: "background.jpg"
+                anchors.fill: parent
+            }
+
+            Loader {
+                id: watchfaceLoader
+
+                anchors.fill: parent
+                source: appRoot.nameOfWatchfaceToBeTested 
+                        + "/usr/share/asteroid-launcher/watchfaces/" 
+                        + appRoot.nameOfWatchfaceToBeTested + ".qml"
+            }
+
+            layer.effect: OpacityMask {
+                anchors.fill: parent
+                source: frame
+
+                maskSource: Rectangle {
+                    width: frame.width
+                    height: frame.height
+                    radius: frame.width / 2
+                }
+            }
+        }
+
+        Item {
+            id: use12H
+
+            property bool value: twelveHourCheckBox.checked
+        }
+
+        Item {
+            id: wallClock
+
+            property var time: getDisplayTime()
+
+            function getDisplayTime(statictime) {
+                var displayTime = new Date();
+                if (setStaticTimeCheckBox.checked) {
+                    displayTime.setHours(hoursTumbler.currentIndex, minutesTumbler.currentIndex, secondsTumbler.currentIndex);
+                    displayTime.setMonth(monthsTumbler.currentIndex, daysTumbler.currentIndex + 1);
+                }
+                return displayTime;
+            }
+
+            Timer {
+                interval: 1000
+                running: true
+                repeat: true
+                onTriggered: wallClock.time = wallClock.getDisplayTime()
+            }
         }
     }
 }

--- a/loader.qml
+++ b/loader.qml
@@ -11,378 +11,381 @@ ApplicationWindow {
     readonly property var initialStaticTime: new Date('2021-12-02T13:37:42')
     readonly property real mouseWheelScale: 1 / 15
 
-    minimumWidth: 640
-    minimumHeight: 640 + header.height
+    minimumWidth: 640 + controls.width
+    minimumHeight: 640
 
-    header: ToolBar {
-        ColumnLayout {
-            RowLayout {
-                Layout.alignment: Qt.AlignCenter
-
-                Button {
-                    id: reloadButton
-
-                    flat: false
-                    text: "\u27f2"
-                    ToolTip.visible: hovered
-                    ToolTip.delay: 600
-                    ToolTip.text: qsTr("Reload qml code")
-                    onClicked: {
-                        watchfaceLoader.source = appRoot.nameOfWatchfaceToBeTested
-                                + "/usr/share/asteroid-launcher/watchfaces/"
-                                + appRoot.nameOfWatchfaceToBeTested + ".qml?"
-                                + Math.random();
-                    }
-                }
-
-                Button {
-                    id: screenshotButton
-
-                    flat: false
-                    text: qsTr("Screenshot")
-                    ToolTip.visible: hovered
-                    ToolTip.delay: 600
-                    ToolTip.text: qsTr("Take a 640px screenshot and store it as PNG image")
-                    onClicked: roundCheckBox.checked ? watchfaceDisplayFrame.snapshot("-screenshot.png") : watchfaceDisplayFrame.snapshot(".png")
-                }
-
-                Button {
-                    id: previewButton
-
-                    property real sequencer: 0
-
-                    function transSnapshots() {
-                        if (sequencer === 1) {
-                            watchfaceDisplayFrame.color = "transparent";
-                            background.source = "";
-                            frame.color = "transparent";
-                            watchfaceDisplayFrame.snapshot("-trans.png");
-                        }
-
-                        if (sequencer === 2) {
-                            background.source = "background.jpg";
-                            roundCheckBox.checked = false;
-                            watchfaceDisplayFrame.snapshot(".png");
-                        }
-
-                        if (sequencer === 3) {
-                            background.source = "background-round.jpg";
-                            roundCheckBox.checked = true;
-                            watchfaceDisplayFrame.snapshot("-round.png");
-                        }
-
-                        if (sequencer === 4) {
-                            frame.color = "black";
-                            sequencer = 0;
-                            snapshotsTimer.running = false;
-                        }
-                    }
-
-                    Timer {
-                        id: snapshotsTimer
-                        interval: 500; running: false; repeat: true
-                        onTriggered: {
-                            previewButton.sequencer++
-                            previewButton.transSnapshots()
-                        }
-                    }
-
-                    flat: false
-                    text: qsTr("Generate previews")
-                    ToolTip.visible: hovered
-                    ToolTip.delay: 600
-                    ToolTip.text: qsTr("Generate preview images for the .thumbnails and watchfacepreview folders")
-                    onClicked: snapshotsTimer.running = true
-                }
-            }
-
-            RowLayout {
-                Layout.alignment: Qt.AlignCenter
-
-                ColumnLayout {
+    RowLayout {
+        ToolBar {
+            ColumnLayout {
+                RowLayout {
                     Layout.alignment: Qt.AlignCenter
 
-                    CheckBox {
-                        id: roundCheckBox
+                    Button {
+                        id: reloadButton
 
-                        font.pixelSize: 30
-                        text: "\u25EF"
+                        flat: false
+                        text: "\u27f2"
                         ToolTip.visible: hovered
                         ToolTip.delay: 600
-                        ToolTip.text: qsTr("Show the watchface as it would look on a round watch")
-                        checked: true
+                        ToolTip.text: qsTr("Reload qml code")
+                        onClicked: {
+                            watchfaceLoader.source = appRoot.nameOfWatchfaceToBeTested
+                                    + "/usr/share/asteroid-launcher/watchfaces/"
+                                    + appRoot.nameOfWatchfaceToBeTested + ".qml?"
+                                    + Math.random();
+                        }
                     }
 
-                    CheckBox {
-                        id: nonSquare
+                    Button {
+                        id: screenshotButton
 
-                        font.pixelSize: 30
-                        text: "\u25AF"
+                        flat: false
+                        text: qsTr("Screenshot")
                         ToolTip.visible: hovered
                         ToolTip.delay: 600
-                        ToolTip.text: qsTr("Show the watchface as it would look on a non-square watch")
-                        checked: true
+                        ToolTip.text: qsTr("Take a 640px screenshot and store it as PNG image")
+                        onClicked: roundCheckBox.checked ? watchfaceDisplayFrame.snapshot("-screenshot.png") : watchfaceDisplayFrame.snapshot(".png")
                     }
 
-                    CheckBox {
-                        id: ambientCheckBox
+                    Button {
+                        id: previewButton
 
-                        font.pixelSize: 40
-                        text: "\u263D"
+                        property real sequencer: 0
+
+                        function transSnapshots() {
+                            if (sequencer === 1) {
+                                watchfaceDisplayFrame.color = "transparent";
+                                background.source = "";
+                                frame.color = "transparent";
+                                watchfaceDisplayFrame.snapshot("-trans.png");
+                            }
+
+                            if (sequencer === 2) {
+                                background.source = "background.jpg";
+                                roundCheckBox.checked = false;
+                                watchfaceDisplayFrame.snapshot(".png");
+                            }
+
+                            if (sequencer === 3) {
+                                background.source = "background-round.jpg";
+                                roundCheckBox.checked = true;
+                                watchfaceDisplayFrame.snapshot("-round.png");
+                            }
+
+                            if (sequencer === 4) {
+                                frame.color = "black";
+                                sequencer = 0;
+                                snapshotsTimer.running = false;
+                            }
+                        }
+
+                        Timer {
+                            id: snapshotsTimer
+                            interval: 500; running: false; repeat: true
+                            onTriggered: {
+                                previewButton.sequencer++
+                                previewButton.transSnapshots()
+                            }
+                        }
+
+                        flat: false
+                        text: qsTr("Generate previews")
                         ToolTip.visible: hovered
                         ToolTip.delay: 600
-                        ToolTip.text: qsTr("Switch to AmbientMode on black background")
-                    }
-
-                    CheckBox {
-                        id: halfSize
-
-                        text: qsTr("320px")
-                        ToolTip.visible: hovered
-                        ToolTip.delay: 600
-                        ToolTip.text: qsTr("Scale down view to 320x320px from 640px")
+                        ToolTip.text: qsTr("Generate preview images for the .thumbnails and watchfacepreview folders")
+                        onClicked: snapshotsTimer.running = true
                     }
                 }
 
-                ColumnLayout {
+                RowLayout {
                     Layout.alignment: Qt.AlignCenter
 
-                    CheckBox {
-                        id: twelveHourCheckBox
+                    ColumnLayout {
+                        Layout.alignment: Qt.AlignCenter
 
-                        text: qsTr("12h")
-                        ToolTip.delay: 600
+                        CheckBox {
+                            id: roundCheckBox
+
+                            font.pixelSize: 30
+                            text: "\u25EF"
+                            ToolTip.visible: hovered
+                            ToolTip.delay: 600
+                            ToolTip.text: qsTr("Show the watchface as it would look on a round watch")
+                            checked: true
+                        }
+
+                        CheckBox {
+                            id: nonSquare
+
+                            font.pixelSize: 30
+                            text: "\u25AF"
+                            ToolTip.visible: hovered
+                            ToolTip.delay: 600
+                            ToolTip.text: qsTr("Show the watchface as it would look on a non-square watch")
+                        }
+
+                        CheckBox {
+                            id: ambientCheckBox
+
+                            font.pixelSize: 40
+                            text: "\u263D"
+                            ToolTip.visible: hovered
+                            ToolTip.delay: 600
+                            ToolTip.text: qsTr("Switch to AmbientMode on black background")
+                        }
+
+                        CheckBox {
+                            id: halfSize
+
+                            text: qsTr("320px")
+                            ToolTip.visible: hovered
+                            ToolTip.delay: 600
+                            ToolTip.text: qsTr("Scale down view to 320x320px from 640px")
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.alignment: Qt.AlignCenter
+
+                        CheckBox {
+                            id: twelveHourCheckBox
+
+                            text: qsTr("12h")
+                            ToolTip.delay: 600
+                            ToolTip.visible: hovered
+                            ToolTip.text: qsTr("Switch to 2x 12h day format with am/pm")
+                        }
+
+                        CheckBox {
+                            id: setStaticTimeCheckBox
+
+                            text: qsTr("Set Time")
+                            ToolTip.delay: 600
+                            ToolTip.visible: hovered
+                            ToolTip.text: qsTr("Set a custom time by draging the tumblers or use the mouse wheel above them")
+                            checked: false
+                        }
+                    }
+
+                    Frame {
+                        padding: 0
+
+                        Row {
+                            Tumbler {
+                                id: monthsTumbler
+
+                                enabled: setStaticTimeCheckBox.checked
+                                currentIndex: appRoot.initialStaticTime.getMonth()
+                                model: 12
+
+                                WheelHandler {
+                                    property: "currentIndex"
+                                    rotationScale: appRoot.mouseWheelScale
+                                }
+
+                                delegate: Label {
+                                    text: appRoot.locale.standaloneMonthName(index, Locale.ShortFormat)
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                            }
+
+                            Tumbler {
+                                id: daysTumbler
+
+                                enabled: setStaticTimeCheckBox.checked
+                                currentIndex: appRoot.initialStaticTime.getDate() - 1
+                                model: 31
+
+                                WheelHandler {
+                                    property: "currentIndex"
+                                    rotationScale: appRoot.mouseWheelScale
+                                }
+
+                                delegate: Label {
+                                    text: index + 1
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                            }
+                        }
+                    }
+
+                    Frame {
+                        padding: 0
+
+                        Row {
+                            Tumbler {
+                                id: hoursTumbler
+
+                                enabled: setStaticTimeCheckBox.checked
+                                currentIndex: appRoot.initialStaticTime.getHours()
+                                model: 24
+
+                                WheelHandler {
+                                    property: "currentIndex"
+                                    rotationScale: appRoot.mouseWheelScale
+                                }
+                            }
+
+                            Tumbler {
+                                id: minutesTumbler
+
+                                enabled: setStaticTimeCheckBox.checked
+                                currentIndex: appRoot.initialStaticTime.getMinutes()
+                                model: 60
+
+                                WheelHandler {
+                                    property: "currentIndex"
+                                    rotationScale: appRoot.mouseWheelScale
+                                }
+                            }
+
+                            Tumbler {
+                                id: secondsTumbler
+
+                                enabled: setStaticTimeCheckBox.checked
+                                currentIndex: appRoot.initialStaticTime.getSeconds()
+                                model: 60
+
+                                WheelHandler {
+                                    property: "currentIndex"
+                                    rotationScale: appRoot.mouseWheelScale
+                                }
+                            }
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Text {
+                        leftPadding: 100
+                        text: qsTr("featureSlider")
+                    }
+
+                    Slider {
+                        id: featureSlider
+
+                        width: 700
+                        from: 0
+                        value: 0.5
+                        to: 1
                         ToolTip.visible: hovered
-                        ToolTip.text: qsTr("Switch to 2x 12h day format with am/pm")
-                    }
-
-                    CheckBox {
-                        id: setStaticTimeCheckBox
-
-                        text: qsTr("Set Time")
                         ToolTip.delay: 600
-                        ToolTip.visible: hovered
-                        ToolTip.text: qsTr("Set a custom time by draging the tumblers or use the mouse wheel above them")
-                        checked: false
-                    }
-                }
+                        ToolTip.text: qsTr("Can be used to test a feature such as battery level.\nDevelopers can temporarily use 'featureSlider.value' in watchface code.")
 
-                Frame {
-                    padding: 0
+                        Repeater {
+                            model: 25
 
-                    Row {
-                        Tumbler {
-                            id: monthsTumbler
-
-                            enabled: setStaticTimeCheckBox.checked
-                            currentIndex: appRoot.initialStaticTime.getMonth()
-                            model: 12
-
-                            WheelHandler {
-                                property: "currentIndex"
-                                rotationScale: appRoot.mouseWheelScale
-                            }
-
-                            delegate: Label {
-                                text: appRoot.locale.standaloneMonthName(index, Locale.ShortFormat)
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
+                            delegate: Rectangle {
+                                anchors.bottom: parent.bottom
+                                x: parent.horizontalPadding + parent.availableWidth * index / 24
+                                implicitWidth: 1
+                                implicitHeight: 8
+                                color: "brown"
                             }
                         }
 
-                        Tumbler {
-                            id: daysTumbler
-
-                            enabled: setStaticTimeCheckBox.checked
-                            currentIndex: appRoot.initialStaticTime.getDate() - 1
-                            model: 31
-
-                            WheelHandler {
-                                property: "currentIndex"
-                                rotationScale: appRoot.mouseWheelScale
-                            }
-
-                            delegate: Label {
-                                text: index + 1
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                            }
-                        }
-                    }
-                }
-
-                Frame {
-                    padding: 0
-
-                    Row {
-                        Tumbler {
-                            id: hoursTumbler
-
-                            enabled: setStaticTimeCheckBox.checked
-                            currentIndex: appRoot.initialStaticTime.getHours()
-                            model: 24
-
-                            WheelHandler {
-                                property: "currentIndex"
-                                rotationScale: appRoot.mouseWheelScale
-                            }
+                        Text {
+                            text: "0.0"
+                            anchors.left: parent.left
                         }
 
-                        Tumbler {
-                            id: minutesTumbler
-
-                            enabled: setStaticTimeCheckBox.checked
-                            currentIndex: appRoot.initialStaticTime.getMinutes()
-                            model: 60
-
-                            WheelHandler {
-                                property: "currentIndex"
-                                rotationScale: appRoot.mouseWheelScale
-                            }
-                        }
-
-                        Tumbler {
-                            id: secondsTumbler
-
-                            enabled: setStaticTimeCheckBox.checked
-                            currentIndex: appRoot.initialStaticTime.getSeconds()
-                            model: 60
-
-                            WheelHandler {
-                                property: "currentIndex"
-                                rotationScale: appRoot.mouseWheelScale
-                            }
-                        }
-                    }
-                }
-            }
-
-            RowLayout {
-                Text {
-                    leftPadding: 100
-                    text: qsTr("featureSlider")
-                }
-
-                Slider {
-                    id: featureSlider
-
-                    width: 700
-                    from: 0
-                    value: 0.5
-                    to: 1
-                    ToolTip.visible: hovered
-                    ToolTip.delay: 600
-                    ToolTip.text: qsTr("Can be used to test a feature such as battery level.\nDevelopers can temporarily use 'featureSlider.value' in watchface code.")
-
-                    Repeater {
-                        model: 25
-
-                        delegate: Rectangle {
-                            anchors.bottom: parent.bottom
-                            x: parent.horizontalPadding + parent.availableWidth * index / 24
-                            implicitWidth: 1
-                            implicitHeight: 8
-                            color: "brown"
+                        Text {
+                            text: "1.0"
+                            anchors.right: parent.right
                         }
                     }
 
                     Text {
-                        text: "0.0"
-                        anchors.left: parent.left
+                        text: featureSlider.value.toFixed(3)
                     }
-
-                    Text {
-                        text: "1.0"
-                        anchors.right: parent.right
-                    }
-                }
-
-                Text {
-                    text: featureSlider.value.toFixed(3)
                 }
             }
+
+            id: controls
+            Layout.fillHeight: true
+            background: Rectangle {
+                color: "lightblue"
+            }
         }
-
-        background: Rectangle {
-            color: "lightblue"
-        }
-    }
-
-    Rectangle {
-        id: watchfaceDisplayFrame
-
-        function snapshot(suffix) {
-            watchfaceDisplayFrame.grabToImage(function(result) {
-                result.saveToFile(appRoot.nameOfWatchfaceToBeTested + suffix);
-            }, Qt.size(640, 640));
-        }
-
-        height: halfSize.checked ? 320 : 640
-        width: nonSquare.checked ? height * 0.85 : height
 
         Rectangle {
-            id: frame
+            id: watchfaceDisplayFrame
 
-            anchors.fill: parent
-            color: "black"
-            focus: true
-            layer.enabled: roundCheckBox.checked
-            Keys.onReturnPressed: watchfaceDisplayFrame.snapshot()
-
-            Image {
-                id: background
-
-                visible: !appRoot.displayAmbient
-                source: "background.jpg"
-                anchors.fill: parent
+            function snapshot(suffix) {
+                watchfaceDisplayFrame.grabToImage(function(result) {
+                    result.saveToFile(appRoot.nameOfWatchfaceToBeTested + suffix);
+                }, Qt.size(640, 640));
             }
 
-            Loader {
-                id: watchfaceLoader
+            height: halfSize.checked ? 320 : 640
+            width: nonSquare.checked ? height * 0.85 : height
+
+            Rectangle {
+                id: frame
 
                 anchors.fill: parent
-                source: appRoot.nameOfWatchfaceToBeTested 
-                        + "/usr/share/asteroid-launcher/watchfaces/" 
-                        + appRoot.nameOfWatchfaceToBeTested + ".qml"
-            }
+                color: "black"
+                focus: true
+                layer.enabled: roundCheckBox.checked
+                Keys.onReturnPressed: watchfaceDisplayFrame.snapshot()
 
-            layer.effect: OpacityMask {
-                anchors.fill: parent
-                source: frame
+                Image {
+                    id: background
 
-                maskSource: Rectangle {
-                    width: frame.width
-                    height: frame.height
-                    radius: frame.width / 2
+                    visible: !appRoot.displayAmbient
+                    source: "background.jpg"
+                    anchors.fill: parent
+                }
+
+                Loader {
+                    id: watchfaceLoader
+
+                    anchors.fill: parent
+                    source: appRoot.nameOfWatchfaceToBeTested
+                            + "/usr/share/asteroid-launcher/watchfaces/"
+                            + appRoot.nameOfWatchfaceToBeTested + ".qml"
+                }
+
+                layer.effect: OpacityMask {
+                    anchors.fill: parent
+                    source: frame
+
+                    maskSource: Rectangle {
+                        width: frame.width
+                        height: frame.height
+                        radius: frame.width / 2
+                    }
                 }
             }
-        }
 
-        Item {
-            id: use12H
+            Item {
+                id: use12H
 
-            property bool value: twelveHourCheckBox.checked
-        }
-
-        Item {
-            id: wallClock
-
-            property var time: getDisplayTime()
-
-            function getDisplayTime(statictime) {
-                var displayTime = new Date();
-                if (setStaticTimeCheckBox.checked) {
-                    displayTime.setHours(hoursTumbler.currentIndex, minutesTumbler.currentIndex, secondsTumbler.currentIndex);
-                    displayTime.setMonth(monthsTumbler.currentIndex, daysTumbler.currentIndex + 1);
-                }
-                return displayTime;
+                property bool value: twelveHourCheckBox.checked
             }
 
-            Timer {
-                interval: 1000
-                running: true
-                repeat: true
-                onTriggered: wallClock.time = wallClock.getDisplayTime()
+            Item {
+                id: wallClock
+
+                property var time: getDisplayTime()
+
+                function getDisplayTime(statictime) {
+                    var displayTime = new Date();
+                    if (setStaticTimeCheckBox.checked) {
+                        displayTime.setHours(hoursTumbler.currentIndex, minutesTumbler.currentIndex, secondsTumbler.currentIndex);
+                        displayTime.setMonth(monthsTumbler.currentIndex, daysTumbler.currentIndex + 1);
+                    }
+                    return displayTime;
+                }
+
+                Timer {
+                    interval: 1000
+                    running: true
+                    repeat: true
+                    onTriggered: wallClock.time = wallClock.getDisplayTime()
+                }
             }
         }
     }

--- a/loader.qml
+++ b/loader.qml
@@ -131,25 +131,25 @@ ApplicationWindow {
                     property real sequencer: 0
 
                     function transSnapshots() {
-                        if (sequencer === 0) {
+                        if (sequencer === 1) {
                             watchfaceDisplayFrame.color = "transparent";
                             background.source = "";
                             frame.color = "transparent";
                             watchfaceDisplayFrame.snapshot("-trans.png");
                         }
 
-                        if (sequencer === 1) {
+                        if (sequencer === 2) {
                             background.source = "background-round.jpg";
                             watchfaceDisplayFrame.snapshot("-round.png");
                         }
 
-                        if (sequencer === 2) {
+                        if (sequencer === 3) {
                             background.source = "background.jpg";
                             roundCheckBox.checked = false;
                             watchfaceDisplayFrame.snapshot(".png");
                         }
 
-                        if (sequencer === 3) {
+                        if (sequencer === 4) {
                             frame.color = "black";
                             roundCheckBox.checked = true;
                             sequencer = 0;
@@ -161,8 +161,8 @@ ApplicationWindow {
                         id: snapshotsTimer
                         interval: 500; running: false; repeat: true
                         onTriggered: {
-                            previewButton.transSnapshots()
                             previewButton.sequencer++
+                            previewButton.transSnapshots()
                         }
                     }
 


### PR DESCRIPTION
Currently, qmlscene is hardcoded to at least 640x955, not including window decoration. That height doesn't fit well on resolutions under 1080p. For example, I primarily use a laptop with a 1366x768 display, and a 1600x900 monitor above it when docked. You can see here that even on the larger monitor, it cuts across both displays. This is exaggeratedly worse if the majority is on the small display, with the header cut in half across screens.

![screenshot showing that it cuts across](https://user-images.githubusercontent.com/35016761/191574286-778e09c6-1a33-48d1-98ee-4f29d2d6dea5.png)

I decided the best way to get around this would be to move the controls to the side, making the window horizontally shaped. 

![redesign preview](https://user-images.githubusercontent.com/35016761/191618318-0aba923c-b64f-422c-a29a-95dc72a0c96a.png)

On top of this, I have fixed a couple of things:
- Generate previews will always regenerate the transparent image
- Generate previews never assumes status of round option
- Non-square option no longer enabled on startup

Git did a TERRIBLE job diffing this, because I had to rearranged pretty much everything and nest a lot of code. But I've tried to make the commit history somewhat clean. The most complex one is 271ea91e6d491e669e210830ba7a9c17ee0ddced where I nested everything into a RowLayout and it didn't know what to do. In that commit I had also changed the width/height at the top, and removed `checked: true` from the non-square checkbox.

For anyone interested, I had originally wanted to change the icons. But they're actually text, and it seems a bit too complex to replace it with drawing real images. Though before I realized that, I designed this icon for the non-square button. So if anyone ever decides to change the icons, have this for free :)
![redesigned non square icon](https://user-images.githubusercontent.com/35016761/191618545-6d606a42-1c2f-4375-bc34-e30ff7ffe0f5.png)