### PR TITLE
[analog-boombox] Correct battery segments display

### DIFF
--- a/analog-boombox/usr/share/asteroid-launcher/watchfaces/analog-boombox.qml
+++ b/analog-boombox/usr/share/asteroid-launcher/watchfaces/analog-boombox.qml
@@ -167,7 +167,7 @@ Item {
             Shape {
                 id: segment
 
-                visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue / 100
 
                 ShapePath {
                     fillColor: "transparent"


### PR DESCRIPTION
Shame, shame, shame :P
Initial PR was only tested/developed on watches with 100% charge...
Now installing on a watch with lower charge, it became apparent that i missed to divide by 100. uh uh