### PR TITLE
Persist settings

### DIFF
--- a/loader.qml
+++ b/loader.qml
@@ -3,6 +3,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.2
+import Qt.labs.settings 1.0
 
 ApplicationWindow {
     id: appRoot
@@ -14,6 +15,15 @@ ApplicationWindow {
 
     minimumWidth: 640 + controls.width
     minimumHeight: 640
+
+    Settings {
+        property alias round: roundCheckBox.checked
+        property alias nonSquare: nonSquare.checked
+        property alias displayAmbient: ambientCheckBox.checked
+        property alias halfSize: halfSize.checked
+        property alias twelveHour: twelveHourCheckBox.checked
+        property alias staticTime: setStaticTimeCheckBox.checked
+    }
 
     RowLayout {
         spacing: 0


### PR DESCRIPTION
This fixes #83 by persisting the settings.  Note that because we do not set the Qt.application.name and Qt.application.organization the settings are stored under ~/.config/QtProject/QtQmlViewer.conf

Signed-off-by: Ed Beroset <beroset@ieee.org>