### PR TITLE
Fix pushFiles function

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -53,10 +53,11 @@ function setDconf {
 function pushFiles {
     local source="$1"
     local destination="$2"
+    IFS=
     if [ "$ADB" = true ] ; then
-        adb push "${source}" "${destination}"
+        adb push ${source} "${destination}"
     else
-        scp -P"${WATCHPORT}" -r "${source}" "root@${WATCHADDR}:${destination}"
+        scp -P"${WATCHPORT}" -r ${source} "root@${WATCHADDR}:${destination}"
     fi
 }
 


### PR DESCRIPTION
The previous commit added quotes around ${source} but the script requires them to be unquoted.  This fixes issue #97 and preserves the ability to push wallpaper from other directories, even if the directory or file name happens to have a space in the name.  That's why the IFS= line is there.

Signed-off-by: Ed Beroset <beroset@ieee.org>