### PR TITLE
numerals-duo-synth-neon-green: Add a transition animation between AoD and normal mode.

### DIFF
--- a/numerals-duo-synth-neon-green/usr/share/asteroid-launcher/watchfaces/numerals-duo-synth-neon-green.qml
+++ b/numerals-duo-synth-neon-green/usr/share/asteroid-launcher/watchfaces/numerals-duo-synth-neon-green.qml
@@ -93,6 +93,10 @@ Item {
         y: DeviceInfo.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
         width: DeviceInfo.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
         height: DeviceInfo.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
+        Behavior on x { NumberAnimation { duration: 50; easing.type: Easing.OutQuad } }
+        Behavior on y { NumberAnimation { duration: 50; easing.type: Easing.OutQuad } }
+        Behavior on width { NumberAnimation { duration: 50; easing.type: Easing.OutQuad } }
+        Behavior on height { NumberAnimation { duration: 50; easing.type: Easing.OutQuad } }
 
         LinearGradient {
             id: greenColor


### PR DESCRIPTION
This smoothens the transition between the AoD mode (4 digit only) and normal mode (4 digits and date info) by adding a short animation.

Preview:

https://user-images.githubusercontent.com/7857908/218314603-66dbba41-1e6c-4ee2-9c90-1a988f6f8ef7.mp4

