### PR TITLE
Add update command to watchface

### DIFF
--- a/watchface
+++ b/watchface
@@ -1,5 +1,5 @@
 #! /bin/bash
-VERSION="1.0"
+VERSION="1.1"
 
 function showVersion {
     echo "watchface v${VERSION}"
@@ -13,20 +13,21 @@ Utility functions for AsteroidOS watchfaces.  By default, uses "Developer Mode"
 over ssh, but can also use "ADB Mode" using ADB.
 
 Available options:
--h or --help    prints this help screen and quits
--a or --adb     uses ADB command to communicate with watch
+-h or --help    print this help screen and quit
+-a or --adb     use ADB command to communicate with watch
 -b or --boot    reboot watch after deploying multiple watchfaces
 -g or --gui     use the GTK+ gui
--p or --port    specifies a port to use for ssh and scp commands
--r or --remote  specifies the remote (watch)  name or address for ssh and scp commands
--q or --qemu    communicates with QEMU emulated watch (same as -r localhost -p 2222 )
--w or --wall WP sets the wallpaper for deploy or test to the named file
+-p or --port    specify an IP port to use for ssh and scp commands
+-r or --remote  specify the remote (watch)  name or address for ssh and scp commands
+-q or --qemu    communicate with QEMU emulated watch (same as -r localhost -p 2222 )
+-w or --wall WP set the wallpaper for deploy or test to the named file
 
 Available commands:
-version         displays the version of this program and exits
-deploy WF       pushes the named watchface to the watch and activates it
-clone WF NEWWF  clones the named watchface WF to new watchface NEWWF
-test WF         tests the named watchface on the computer using qmlscene
+update          use git to update your local copy of the unoffical-watchfaces repository
+version         display the version of this program and exit
+deploy WF       push the named watchface to the watch and activate it
+clone WF NEWWF  clone the named watchface WF to new watchface NEWWF
+test WF         test the named watchface on the computer using qmlscene
 
 EOF
 }
@@ -365,6 +366,11 @@ while [[ $# -gt 0 ]] ; do
         test)
             testface "$2"
             shift
+            shift
+            SKIP_INTERACTIVE_PROMPT=true
+            ;;
+        update)
+            git pull
             shift
             SKIP_INTERACTIVE_PROMPT=true
             ;;


### PR DESCRIPTION
This adds the update command to the watchface program and updates the version to 1.1.  When the user types "watchface update" it now runs "git pull" to update the project.  This was a suggestion from @dodoradio in response to an observation by @totalsonic1 in Matrix.