### PR TITLE
Fix whiptail multiple watch selection

### DIFF
--- a/watchface
+++ b/watchface
@@ -307,7 +307,7 @@ WALLPAPER=""
 if hash dialog 2>/dev/null; then
     MENUPROGRAM=dialog
 else
-    MENUPROGRAM=whiptail
+    MENUPROGRAM=whiptail --separate-output
 fi
 
 


### PR DESCRIPTION
This fixes #109 by using the --separate-output option to avoid introducing quotation marks in output lists and to give better compatibility with dialog.