### PR TITLE
Add all option

### DIFF
--- a/watchface
+++ b/watchface
@@ -128,8 +128,7 @@ function sanitizeSourceWatchface {
 function deployface {
     local sourcewatchface
     local activate="$2"
-    sourcewatchface=$(sanitizeSourceWatchface "$1") 
-    if [ $? -ne 0 ] ; then
+    if ! sourcewatchface=$(sanitizeSourceWatchface "$1") ; then
         exit 1
     fi
     echo "Deploying ${sourcewatchface}"
@@ -144,8 +143,7 @@ function deployface {
 
 function testface {
     local sourcewatchface
-    sourcewatchface=$(sanitizeSourceWatchface "$1")
-    if [ $? -ne 0 ] ; then
+    if ! sourcewatchface=$(sanitizeSourceWatchface "$1") ; then
         exit 1
     fi
     echo "Testing ${sourcewatchface}"
@@ -159,8 +157,7 @@ function testface {
 function cloneface {
     local sourcewatchface
     local destwatchface="$2"
-    sourcewatchface=$(sanitizeSourceWatchface "$1")
-    if [ $? -ne 0 ] ; then
+    if ! sourcewatchface=$(sanitizeSourceWatchface "$1") ; then
         exit 1
     fi
     echo "Cloning ${sourcewatchface} into ${destwatchface}"

--- a/watchface
+++ b/watchface
@@ -16,6 +16,7 @@ Available options:
 -h or --help    print this help screen and quit
 -a or --adb     use ADB command to communicate with watch
 -b or --boot    reboot watch after deploying multiple watchfaces
+-e or --every   select every watchface (deploy only)
 -g or --gui     use the GTK+ gui
 -p or --port    specify an IP port to use for ssh and scp commands
 -r or --remote  specify the remote (watch)  name or address for ssh and scp commands
@@ -171,6 +172,7 @@ function cloneface {
 function guiMenu {
     local watchface
     local action
+    local default
     if ! action=$(zenity --title="Select action" --list --radiolist \
         --column="selected" --column="action" \
         TRUE deploy \
@@ -178,11 +180,16 @@ function guiMenu {
         FALSE test); then
         exit
     fi
+    if [ "${DEFAULTOPTION}" == "ON" ] ; then
+        default=TRUE
+    else
+        default=FALSE
+    fi
     case $action in 
         deploy)
             declare -a args=('--title="Choose watchfaces"' "--list" "--checklist" '--column="Selected"' '--column="Name"')
             for wf in "${WATCHFACES[@]}" ; do
-                args+=(FALSE "${wf}")
+                args+=("${default}" "${wf}")
             done
             if ! watchface=$(zenity "${args[@]}"); then
                 exit
@@ -239,7 +246,7 @@ function textMenu {
         deploy)
             declare -a args=("--title" "Watchfaces" "--clear" "--checklist" "Choose watchfaces:" 25 78 15 "--" )
             for wf in "${WATCHFACES[@]}" ; do
-                args+=("${wf}" "" OFF)
+                args+=("${wf}" "" "${DEFAULTOPTION}")
             done
             if ! watchface=$(${MENUPROGRAM} "${args[@]}" 3>&1 1>&2 2>&3); then
                 exit
@@ -300,6 +307,8 @@ GUI=false
 SKIP_INTERACTIVE_PROMPT=false
 # No wallpaper unless asked
 WALLPAPER=""
+# Default to all watchfaces unselected for deploy
+DEFAULTOPTION=OFF
 # Assume Dialog unless unavailable
 if hash dialog 2>/dev/null; then
     MENUPROGRAM="dialog"
@@ -316,6 +325,10 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -b|--boot)
             REBOOT=true
+            shift
+            ;;
+        -e|--every)
+            DEFAULTOPTION=ON
             shift
             ;;
         -g|--gui)

--- a/watchface
+++ b/watchface
@@ -321,9 +321,9 @@ DEFAULTOPTION=OFF
 DEPLOY_ALL=false
 # Assume Dialog unless unavailable
 if hash dialog 2>/dev/null; then
-    MENUPROGRAM=dialog
+    MENUPROGRAM="dialog"
 elif hash whiptail 2>/dev/null; then
-    MENUPROGRAM=whiptail --separate-output
+    MENUPROGRAM="whiptail --separate-output"
 fi
 
 while [[ $# -gt 0 ]] ; do

--- a/watchface
+++ b/watchface
@@ -185,7 +185,7 @@ function guiMenu {
     else
         default=FALSE
     fi
-    case $action in 
+    case $action in
         deploy)
             declare -a args=('--title="Choose watchfaces"' "--list" "--checklist" '--column="Selected"' '--column="Name"')
             for wf in "${WATCHFACES[@]}" ; do
@@ -242,7 +242,7 @@ function textMenu {
         3>&1 1>&2 2>&3); then
         exit
     fi
-    case $action in 
+    case $action in
         deploy)
             declare -a args=("--title" "Watchfaces" "--clear" "--checklist" "Choose watchfaces:" 25 78 15 "--" )
             for wf in "${WATCHFACES[@]}" ; do

--- a/watchface
+++ b/watchface
@@ -227,7 +227,7 @@ function textMenu {
     local args
     local watchface
     local newface
-    if ! action=$("${MENUPROGRAM}" --title "Select action" --clear --radiolist \
+    if ! action=$(${MENUPROGRAM} --title "Select action" --clear --radiolist \
         "Select action" 0 0 3 \
         "deploy" "Deploy watchface to watch" ON \
         "clone" "Clone watchface to new name" OFF \
@@ -241,7 +241,7 @@ function textMenu {
             for wf in "${WATCHFACES[@]}" ; do
                 args+=("${wf}" "" OFF)
             done
-            if ! watchface=$("${MENUPROGRAM}" "${args[@]}" 3>&1 1>&2 2>&3); then
+            if ! watchface=$(${MENUPROGRAM} "${args[@]}" 3>&1 1>&2 2>&3); then
                 exit
             fi
             ;;
@@ -250,15 +250,15 @@ function textMenu {
             for wf in "${WATCHFACES[@]}" ; do
                 args+=("${wf}" "")
             done
-            if ! watchface=$("${MENUPROGRAM}" "${args[@]}" 3>&1 1>&2 2>&3); then
+            if ! watchface=$(${MENUPROGRAM} "${args[@]}" 3>&1 1>&2 2>&3); then
                 exit
             fi
             ;;
     esac
-    if ("${MENUPROGRAM}" --clear --title "Confirming" --yesno "${action} ${watchface}" 0 0); then
+    if (${MENUPROGRAM} --clear --title "Confirming" --yesno "${action} ${watchface}" 0 0); then
         echo "OK!"
         if [ "${action}" = "clone" ] ; then
-            if newface=$("${MENUPROGRAM}" \
+            if newface=$(${MENUPROGRAM} \
                 --title "Cloning ${watchface}" --clear \
                 --inputbox "Enter name of new watchface:" \
                 8 50 "newface" \
@@ -302,9 +302,9 @@ SKIP_INTERACTIVE_PROMPT=false
 WALLPAPER=""
 # Assume Dialog unless unavailable
 if hash dialog 2>/dev/null; then
-    MENUPROGRAM=dialog
+    MENUPROGRAM="dialog"
 else
-    MENUPROGRAM=whiptail --separate-output
+    MENUPROGRAM="whiptail --separate-output"
 fi
 
 

--- a/watchface
+++ b/watchface
@@ -27,6 +27,7 @@ Available commands:
 update          use git to update your local copy of the unoffical-watchfaces repository
 version         display the version of this program and exit
 deploy WF       push the named watchface to the watch and activate it
+deployall       deploy all watchfaces
 clone WF NEWWF  clone the named watchface WF to new watchface NEWWF
 test WF         test the named watchface on the computer using qmlscene
 
@@ -292,6 +293,13 @@ function textMenu {
     fi
 }
 
+function deployall {
+    for wf in "${WATCHFACES[@]}" ; do
+        deployface "${wf}" false
+    done
+}
+
+
 # These are the defaults for SSH access
 WATCHPORT=22
 WATCHADDR=192.168.2.15
@@ -309,6 +317,8 @@ SKIP_INTERACTIVE_PROMPT=false
 WALLPAPER=""
 # Default to all watchfaces unselected for deploy
 DEFAULTOPTION=OFF
+# Default to not deploying all watchfaces
+DEPLOY_ALL=false
 # Assume Dialog unless unavailable
 if hash dialog 2>/dev/null; then
     MENUPROGRAM="dialog"
@@ -366,6 +376,11 @@ while [[ $# -gt 0 ]] ; do
             shift
             SKIP_INTERACTIVE_PROMPT=true
             ;;
+        deployall)
+            DEPLOY_ALL=true
+            shift
+            SKIP_INTERACTIVE_PROMPT=true
+            ;;
         deploy)
             deployface "$2" true
             restartCeres
@@ -396,11 +411,13 @@ while [[ $# -gt 0 ]] ; do
     esac
 done
 
+mapfile -t WATCHFACES < <(find . -maxdepth 3 -type d -path "*/usr/share" -printf "%h\n" | sort | awk -F '/' '{print $2}' )
 if [ "${SKIP_INTERACTIVE_PROMPT}" != "true" ] ; then
-    mapfile -t WATCHFACES < <(find . -maxdepth 3 -type d -path "*/usr/share" -printf "%h\n" | sort | awk -F '/' '{print $2}' )
     if [ "${GUI}" = "true" ] ; then
         guiMenu
     else
         textMenu
     fi
+elif [ "${DEPLOY_ALL}" == "true" ] ; then
+    deployall
 fi


### PR DESCRIPTION
This adds a few style improvements and also adds new non-interactive command "deployall" to deploy all watchfaces from the command line, and a similar "-e" or "--every" option to check all boxes by default when using the interactive version.