### PR TITLE
Allow passing an explicit directory for test

### DIFF
--- a/loader.qml
+++ b/loader.qml
@@ -10,6 +10,7 @@ ApplicationWindow {
     property bool displayAmbient: ambientCheckBox.checked
     property var nameOfWatchfaceToBeTested: Qt.application.arguments[1]
     property var backgroundImage: Qt.application.arguments[2]
+    property var relativeRootDir: Qt.application.arguments[3]
     readonly property var initialStaticTime: new Date('2021-12-02T13:37:42')
     readonly property real mouseWheelScale: 1 / 15
     title: nameOfWatchfaceToBeTested
@@ -48,8 +49,7 @@ ApplicationWindow {
                         ToolTip.delay: 600
                         ToolTip.text: qsTr("Reload qml code")
                         onClicked: {
-                            watchfaceLoader.source = appRoot.nameOfWatchfaceToBeTested
-                                    + "/usr/share/asteroid-launcher/watchfaces/"
+                            watchfaceLoader.source = appRoot.relativeRootDir
                                     + appRoot.nameOfWatchfaceToBeTested + ".qml?"
                                     + Math.random();
                         }
@@ -360,8 +360,7 @@ ApplicationWindow {
                     id: watchfaceLoader
 
                     anchors.fill: parent
-                    source: appRoot.nameOfWatchfaceToBeTested
-                            + "/usr/share/asteroid-launcher/watchfaces/"
+                    source: appRoot.relativeRootDir
                             + appRoot.nameOfWatchfaceToBeTested + ".qml"
                 }
 

--- a/watchface
+++ b/watchface
@@ -150,9 +150,9 @@ function testface {
     fi
     echo "Testing ${sourcewatchface}"
     if [ -n "${WALLPAPER}" ] ; then
-        qmlscene "${sourcewatchface}" "${WALLPAPER}" loader.qml
+        qmlscene "${sourcewatchface}" "${WALLPAPER}" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     else
-        qmlscene "${sourcewatchface}" "background.jpg" loader.qml
+        qmlscene "${sourcewatchface}" "background.jpg" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     fi
 }
 


### PR DESCRIPTION
This adds an additional argument to loader.qml to specify the directory in which the watchface is loaded, and then modifies the watchface code to pass that argument.  The purpose is to allow for desktop testing of other kinds of qml files intended for watches.