### PR TITLE
[analog-weather-glow] Fix check for no weather data

### DIFF
--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -442,9 +442,7 @@ Item {
             defaultValue: 0
         }
 
-        // Work around for the beta release here. Currently catching for -273° string to display the no data message.
-        // Plan is to use the commented check. But the result is always false like used now. Likely due to timestamp0 expecting a listview or delegate?
-        property bool weatherSynced: kelvinToTemperatureString(maxTemp.value) !== "-273°" //availableDays(timestampDay0.value*1000) > 0
+        property bool weatherSynced: maxTemp.value != 0
 
         Canvas {
             id: weatherArc


### PR DESCRIPTION
This resolves
https://github.com/AsteroidOS/unofficial-watchfaces/issues/124 by checking for 0K instead of trying to convert before checking.  Now days for which there is no weather data clearly show "No Weather Data" instead of showing -459F regardless of whether the user has chosen C or F for their preferred temperature units.