### PR TITLE
Remove unused MceBatteryState and MceCableState

### DIFF
--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -119,14 +119,6 @@ Item {
             }
         }
 
-        MceBatteryState {
-            id: batteryChargeState
-        }
-
-        MceCableState {
-            id: mceCableState
-        }
-
         Repeater {
             model: 12
 


### PR DESCRIPTION
Just as the title says, these two were included but no longer used.