### PR TITLE
Use temporary fontconfig script for testing watchfaces with custom fonts

### DIFF
--- a/watchface
+++ b/watchface
@@ -143,16 +143,46 @@ function deployface {
     fi
 }
 
+function deleteTempFontconfig {
+    local temp_font_config="$1"
+    echo "Deleting temporary fontconfig config file \"${temp_font_config}\""
+    rm -f "${temp_font_config}"
+}
+
 function testface {
     local sourcewatchface
     if ! sourcewatchface=$(sanitizeSourceWatchface "$1") ; then
         exit 1
     fi
     echo "Testing ${sourcewatchface}"
+
+    # Create a temporary fontconfig configuration file that points to the
+    # fonts subdirectory of the watchface. This allows Qt to load the font
+    # from that local directory - very useful when testing a watch, because
+    # then, installing that font is not necessary.
+    # Normally, using the FONTCONFIG_PATH environment variable would be
+    # sufficient, and a temporary config file would be unnecessary. However,
+    # FONTCONFIG_PATH does not work on Ubuntu 24.04 at least, while
+    # FONTCONFIG_FILE does. Hence this need for a temporary config file.
+
+    local temp_font_config
+    temp_font_config=$(mktemp -t temp_font_config.XXXXXX) || { echo "Failed to generate temporary fontconfig config file"; exit 1; }
+
+    echo "Generating temporary fontconfig config file \"${temp_font_config}\""
+
+    trap "deleteTempFontconfig \"${temp_font_config}\"" EXIT
+
+    cat <<EOF > "${temp_font_config}"
+<?xml version="1.0"?><!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <dir>$(pwd)/${sourcewatchface}/usr/share/fonts/</dir>
+</fontconfig>
+EOF
+
     if [ -n "${WALLPAPER}" ] ; then
-        qmlscene "${sourcewatchface}" "${WALLPAPER}" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
+        FONTCONFIG_FILE="${temp_font_config}" qmlscene "${sourcewatchface}" "${WALLPAPER}" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     else
-        qmlscene "${sourcewatchface}" "background.jpg" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
+        FONTCONFIG_FILE="${temp_font_config}" qmlscene "${sourcewatchface}" "background.jpg" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     fi
 }
 


### PR DESCRIPTION
This obviates the need for copying the font files to the local or system wide font directories.