### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/numerals-duo-neon-green/usr/share/asteroid-launcher/watchfaces/numerals-duo-neon-green.qml
+++ b/numerals-duo-neon-green/usr/share/asteroid-launcher/watchfaces/numerals-duo-neon-green.qml
@@ -34,10 +34,10 @@ Item {
     id: root
 
     Item {
-        x: DeviceInfo.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : 0)
-        y: DeviceInfo.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : 0)
-        width: DeviceInfo.hasRoundScreen ? length * 0.8 : length
-        height: DeviceInfo.hasRoundScreen ? length * 0.8 : length
+        x: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : 0)
+        y: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : 0)
+        width: DeviceSpecs.hasRoundScreen ? length * 0.8 : length
+        height: DeviceSpecs.hasRoundScreen ? length * 0.8 : length
 
         Rectangle {
             id: greenColor


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56