### PR TITLE
Use different wallpaper for round thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,31 @@ You may [reboot the watch](https://asteroidos.org/wiki/useful-commands/#restart)
 ### `watchface` summary
 If invoked without arguments, the `watchface` command will start a text menu (using [`dialog`](https://invisible-island.net/dialog/) if available, otherwise using [`whiptail`](https://en.wikibooks.org/wiki/Bash_Shell_Scripting/Whiptail)).  A GUI based menu (using [`zenity`](https://help.gnome.org/users/zenity/stable/) is also available using the `-g` option.
 ```
+watchface v1.2
 watchface [option] [command...]
-Utility functions for AsteroidOS watchfaces.  By default, uses "Developer Mode"
+Utility functions for AsteroidOS watchfaces.  By default, uses "SSH Mode"
 over ssh, but can also use "ADB Mode" using ADB.
 
 Available options:
--h or --help    prints this help screen and quits
--a or --adb     uses ADB command to communicate with watch
--b or --boot    reboot watch after deploying multiple watchfaces
--g or --gui     use the GTK+ gui
--p or --port    specifies a port to use for ssh and scp commands
--r or --remote  specifies the remote (watch)  name or address for ssh and scp commands
--q or --qemu    communicates with QEMU emulated watch (same as -r localhost -p 2222 )
--w or --wall WP sets the wallpaper for deploy or test to the named file
+-h or --help            print this help screen and quit
+-a or --adb             use ADB command to communicate with watch
+-b or --boot            reboot watch after deploying multiple watchfaces
+-c or --circlewall WP   set the wallpaper for circular watchface thumbnail to the named file (WP)
+-e or --every           select every watchface (deploy only)
+-g or --gui             use the GTK+ gui
+-p or --port            specify an IP port to use for ssh and scp commands
+-r or --remote          specify the remote (watch)  name or address for ssh and scp commands
+-q or --qemu            communicate with QEMU emulated watch (same as -r localhost -p 2222 )
+-w or --wall WP         set the wallpaper for deploy or test to the named file (WP)
+-v or --verbose         print verbose messages (useful for debugging)
 
 Available commands:
-version         displays the version of this program and exits
-deploy WF       pushes the named watchface to the watch and activates it
-clone WF NEWWF  clones the named watchface WF to new watchface NEWWF
-test WF         sets the active watchface to the named watchface
+update          use git to update your local copy of the unoffical-watchfaces repository
+version         display the version of this program and exit
+deploy WF       push the named watchface to the watch and activate it
+deployall       deploy all watchfaces
+clone WF NEWWF  clone the named watchface WF to new watchface NEWWF
+test WF         test the named watchface on the computer using qmlscene
 ```
 
 ### Cloning a watchface

--- a/loader.qml
+++ b/loader.qml
@@ -10,7 +10,8 @@ ApplicationWindow {
     property bool displayAmbient: ambientCheckBox.checked
     property var nameOfWatchfaceToBeTested: Qt.application.arguments[1]
     property var backgroundImage: Qt.application.arguments[2]
-    property var relativeRootDir: Qt.application.arguments[3]
+    property var backgroundRoundImage: Qt.application.arguments[3]
+    property var relativeRootDir: Qt.application.arguments[4]
     readonly property var initialStaticTime: new Date('2021-12-02T13:37:42')
     readonly property real mouseWheelScale: 1 / 15
     title: nameOfWatchfaceToBeTested
@@ -86,12 +87,13 @@ ApplicationWindow {
                             }
 
                             if (sequencer === 3) {
-                                background.source = appRoot.backgroundImage;
+                                background.source = appRoot.backgroundRoundImage;
                                 roundCheckBox.checked = true;
                                 watchfaceDisplayFrame.snapshot("-round.png");
                             }
 
                             if (sequencer === 4) {
+                                background.source = appRoot.backgroundImage;
                                 frame.color = "black";
                                 sequencer = 0;
                                 snapshotsTimer.running = false;

--- a/watchface
+++ b/watchface
@@ -1,5 +1,5 @@
 #! /bin/bash
-VERSION="1.1"
+VERSION="1.2"
 
 function showVersion {
     echo "watchface v${VERSION}"
@@ -9,20 +9,21 @@ function showHelp {
     showVersion
     cat << EOF
 watchface [option] [command...]
-Utility functions for AsteroidOS watchfaces.  By default, uses "Developer Mode"
+Utility functions for AsteroidOS watchfaces.  By default, uses "SSH Mode"
 over ssh, but can also use "ADB Mode" using ADB.
 
 Available options:
--h or --help      print this help screen and quit
--a or --adb       use ADB command to communicate with watch
--b or --boot      reboot watch after deploying multiple watchfaces
--e or --every     select every watchface (deploy only)
--g or --gui       use the GTK+ gui
--p or --port      specify an IP port to use for ssh and scp commands
--r or --remote    specify the remote (watch)  name or address for ssh and scp commands
--q or --qemu      communicate with QEMU emulated watch (same as -r localhost -p 2222 )
--w or --wall WP   set the wallpaper for deploy or test to the named file (WP)
--v or --verbose   print verbose messages (useful for debugging)
+-h or --help            print this help screen and quit
+-a or --adb             use ADB command to communicate with watch
+-b or --boot            reboot watch after deploying multiple watchfaces
+-c or --circlewall WP   set the wallpaper for circular watchface thumbnail to the named file (WP)
+-e or --every           select every watchface (deploy only)
+-g or --gui             use the GTK+ gui
+-p or --port            specify an IP port to use for ssh and scp commands
+-r or --remote          specify the remote (watch)  name or address for ssh and scp commands
+-q or --qemu            communicate with QEMU emulated watch (same as -r localhost -p 2222 )
+-w or --wall WP         set the wallpaper for deploy or test to the named file (WP)
+-v or --verbose         print verbose messages (useful for debugging)
 
 Available commands:
 update          use git to update your local copy of the unoffical-watchfaces repository
@@ -54,6 +55,7 @@ GUI=false
 SKIP_INTERACTIVE_PROMPT=false
 # No wallpaper unless asked
 WALLPAPER=""
+WALLPAPER_ROUND=""
 # Default to all watchfaces unselected for deploy
 DEFAULTOPTION=OFF
 # Default to not deploying all watchfaces
@@ -253,9 +255,9 @@ EOF
     fi
 
     if [ -n "${WALLPAPER}" ] ; then
-        qmlscene "${sourcewatchface}" "${WALLPAPER}" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
+        qmlscene "${sourcewatchface}" "${WALLPAPER}" "${WALLPAPER_ROUND}" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     else
-        qmlscene "${sourcewatchface}" "background.jpg" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
+        qmlscene "${sourcewatchface}" "background.jpg" "background-round.jpg" "${sourcewatchface}/usr/share/asteroid-launcher/watchfaces/" loader.qml
     fi
     convertPreviews "${sourcewatchface}"
 }
@@ -455,7 +457,7 @@ SCRIPT_DIRPATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # Preprocess command line switches with getopt to rearrange
 # them for easier parsing, separating non-option arguments
 # and option arguments.
-REARRANGED_OPTS=$(getopt -o 'abegqp:r:hw:v' --long 'adb,boot,every,gui,qemu,port:,remote:,help,wall:,verbose' -n "$0" -- "$@")
+REARRANGED_OPTS=$(getopt -o 'abc:egqp:r:hw:v' --long 'adb,boot,circlewall:,every,gui,qemu,port:,remote:,help,wall:,verbose' -n "$0" -- "$@")
 if [[ $? -ne 0 ]]; then
     echo "Error parsing arguments" >&2
     showHelp
@@ -475,6 +477,10 @@ while true; do
         '-b'|'--boot')
             REBOOT=true
             shift
+            ;;
+        '-c'|'--circlewall')
+            WALLPAPER_ROUND="$2"
+            shift 2
             ;;
         '-e'|'--every')
             DEFAULTOPTION=ON


### PR DESCRIPTION
This uses a different wallpaper for round thumbnail images for the web than the main one.  By default, the square preview image will use "background.jpg" and the round preview image will use "background-round.jpg" but these can be overridden with the `--wall` or `--circlewall` options, respectively.

Fixes issue #148.