### PR TITLE
Fix analog-goldie watchface

### DIFF
--- a/analog-goldie/usr/share/asteroid-launcher/watchfaces/analog-goldie.qml
+++ b/analog-goldie/usr/share/asteroid-launcher/watchfaces/analog-goldie.qml
@@ -57,7 +57,7 @@ Item {
             horizontalOffset: 0
             verticalOffset: 0
             radius: 16.0
-            samples: 33
+            samples: 34
             color: Qt.rgba(0, 0, 0, .8)
         }
     }


### PR DESCRIPTION
As reported in issue #153, on `catfish`, the analog-goldie watchface turns the background red almost every time the second hand moves.  After some investigation, it seems that it's the dropshadow on the backPlate, so this makes the minimal possible change to correct the problem.

Fixes #153.