### PR TITLE
decimal-time: fix decimal seconds timing

### DIFF
--- a/decimal-time/usr/share/asteroid-launcher/watchfaces/decimal-time.qml
+++ b/decimal-time/usr/share/asteroid-launcher/watchfaces/decimal-time.qml
@@ -181,7 +181,7 @@ Item {
         font.pixelSize: parent.width*0.15
         anchors.verticalCenterOffset: parent.width*0.016
         textFormat: Text.RichText
-        text: "0.0000"
+        text: getDecimalHours(new Date()).toPrecision(5)
     }
 
     Timer {


### PR DESCRIPTION
Adds a `Timer` to `decimal-time` that updates the decimal time independently from the standard time. Also renames every occurrence of "metric" in said watchface's code to "decimal".