### PR TITLE
Port watchface testing script to Qt6 qml6

### DIFF
--- a/fake-components/Connman/NetworkTechnology.qml
+++ b/fake-components/Connman/NetworkTechnology.qml
@@ -1,6 +1,6 @@
 // need this for Global
-import Nemo.Mce 1.0
-import QtQuick 2.9
+import Nemo.Mce
+import QtQuick
 
 Item {
     property string path

--- a/fake-components/Connman/qmldir
+++ b/fake-components/Connman/qmldir
@@ -1,2 +1,2 @@
 module Connman
-NetworkTechnology 0.2 NetworkTechnology.qml
+NetworkTechnology NetworkTechnology.qml

--- a/fake-components/Nemo/Configuration/ConfigurationValue.qml
+++ b/fake-components/Nemo/Configuration/ConfigurationValue.qml
@@ -1,6 +1,6 @@
 // need this for Global
-import Nemo.Mce 1.0
-import QtQuick 2.9
+import Nemo.Mce
+import QtQuick
 
 Item {
     property string key

--- a/fake-components/Nemo/Configuration/qmldir
+++ b/fake-components/Nemo/Configuration/qmldir
@@ -1,2 +1,2 @@
 module Nemo.Configuration
-ConfigurationValue 1.0 ConfigurationValue.qml
+ConfigurationValue ConfigurationValue.qml

--- a/fake-components/Nemo/Mce/Global.qml
+++ b/fake-components/Nemo/Mce/Global.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick
 pragma Singleton
 
 Item {

--- a/fake-components/Nemo/Mce/MceBatteryLevel.qml
+++ b/fake-components/Nemo/Mce/MceBatteryLevel.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.9
 
 Item {
-    property int percent: Global.battery
+    property int percent: global.battery
 }

--- a/fake-components/Nemo/Mce/MceBatteryLevel.qml
+++ b/fake-components/Nemo/Mce/MceBatteryLevel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick
 
 Item {
     property int percent: global.battery

--- a/fake-components/Nemo/Mce/MceBatteryState.qml
+++ b/fake-components/Nemo/Mce/MceBatteryState.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.9
 
 Item {
-    property int value: Global.batteryChargeState
+    property int value: global.batteryChargeState
 }

--- a/fake-components/Nemo/Mce/MceBatteryState.qml
+++ b/fake-components/Nemo/Mce/MceBatteryState.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick
 
 Item {
     property int value: global.batteryChargeState

--- a/fake-components/Nemo/Mce/MceChargerType.qml
+++ b/fake-components/Nemo/Mce/MceChargerType.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.9
 
 Item {
-    property int value: Global.batteryChargerType
+    property int value: global.batteryChargerType
 }

--- a/fake-components/Nemo/Mce/MceChargerType.qml
+++ b/fake-components/Nemo/Mce/MceChargerType.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.9
+import QtQuick
 
 Item {
     property int value: global.batteryChargerType

--- a/fake-components/Nemo/Mce/qmldir
+++ b/fake-components/Nemo/Mce/qmldir
@@ -1,5 +1,5 @@
 module Nemo.Mce
-singleton Global 1.0 Global.qml
-MceBatteryState 1.0 MceBatteryState.qml
-MceBatteryLevel 1.0 MceBatteryLevel.qml
-MceChargerType 1.0 MceChargerType.qml
+singleton Global Global.qml
+MceBatteryState MceBatteryState.qml
+MceBatteryLevel MceBatteryLevel.qml
+MceChargerType MceChargerType.qml

--- a/fake-components/QtSensors/Compass.qml
+++ b/fake-components/QtSensors/Compass.qml
@@ -1,6 +1,6 @@
 // need this for Global
-import Nemo.Mce 1.0
-import QtQuick 2.9
+import Nemo.Mce
+import QtQuick
 
 Item {
     property bool active: Global.compassActive

--- a/fake-components/QtSensors/HrmSensor.qml
+++ b/fake-components/QtSensors/HrmSensor.qml
@@ -1,6 +1,6 @@
 // need this for Global
-import Nemo.Mce 1.0
-import QtQuick 2.9
+import Nemo.Mce
+import QtQuick
 
 Item {
     property string path

--- a/fake-components/QtSensors/qmldir
+++ b/fake-components/QtSensors/qmldir
@@ -1,3 +1,3 @@
 module QtSensors
-HrmSensor 5.11 HrmSensor.qml
-Compass 5.11 Compass.qml
+HrmSensor HrmSensor.qml
+Compass Compass.qml

--- a/fake-components/org/asteroid/controls/Icon.qml
+++ b/fake-components/org/asteroid/controls/Icon.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 
 Item {
     property string name: ""

--- a/fake-components/org/asteroid/controls/Icon.qml
+++ b/fake-components/org/asteroid/controls/Icon.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.15
+
+Item {
+    property string name: ""
+    property color color: "white"
+}

--- a/fake-components/org/asteroid/controls/qmldir
+++ b/fake-components/org/asteroid/controls/qmldir
@@ -1,2 +1,2 @@
 module org.asteroid.controls
-Icon 1.0 Icon.qml
+Icon Icon.qml

--- a/fake-components/org/asteroid/controls/qmldir
+++ b/fake-components/org/asteroid/controls/qmldir
@@ -1,0 +1,2 @@
+module org.asteroid.controls
+Icon 1.0 Icon.qml

--- a/fake-components/org/asteroid/utils/DeviceSpecs.qml
+++ b/fake-components/org/asteroid/utils/DeviceSpecs.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 pragma Singleton
 
 QtObject {

--- a/fake-components/org/asteroid/utils/DeviceSpecs.qml
+++ b/fake-components/org/asteroid/utils/DeviceSpecs.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+pragma Singleton
+
+QtObject {
+    readonly property bool hasRoundScreen: true
+    readonly property int screenPixels: 320
+}

--- a/fake-components/org/asteroid/utils/qmldir
+++ b/fake-components/org/asteroid/utils/qmldir
@@ -1,0 +1,2 @@
+module org.asteroid.utils
+singleton DeviceSpecs 1.0 DeviceSpecs.qml

--- a/fake-components/org/asteroid/utils/qmldir
+++ b/fake-components/org/asteroid/utils/qmldir
@@ -1,2 +1,2 @@
 module org.asteroid.utils
-singleton DeviceSpecs 1.0 DeviceSpecs.qml
+singleton DeviceSpecs DeviceSpecs.qml

--- a/fake-components/qmldir
+++ b/fake-components/qmldir
@@ -1,2 +1,2 @@
 module Fakes
-singleton Global 1.0 Global.qml
+singleton Global Global.qml

--- a/loader.qml
+++ b/loader.qml
@@ -1,26 +1,50 @@
-import Nemo.Mce 1.0
-import Qt.labs.settings 1.0
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
+import QtCore
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.2
+import WatchfaceConfig 1.0
 
 ApplicationWindow {
     id: appRoot
 
     property bool displayAmbient: ambientCheckBox.checked
     property bool nightstand: nightstandCheckBox.checked
-    property var nameOfWatchfaceToBeTested: Qt.application.arguments[1]
-    property var backgroundImage: Qt.application.arguments[2]
-    property var backgroundRoundImage: Qt.application.arguments[3]
-    property var relativeRootDir: Qt.application.arguments[4]
+    property var nameOfWatchfaceToBeTested: WatchfaceConfig.watchfaceName
+    property var backgroundImage: WatchfaceConfig.backgroundImage
+    property var backgroundRoundImage: WatchfaceConfig.backgroundRoundImage
+    property var relativeRootDir: WatchfaceConfig.relativeRootDir
     readonly property var initialStaticTime: new Date('2021-12-02T13:37:42')
     readonly property real mouseWheelScale: 1 / 15
 
     title: nameOfWatchfaceToBeTested
     minimumWidth: 640 + controls.width
     minimumHeight: 640
+    visible: true
+
+    QtObject {
+        id: global
+
+        property real heartrate: 0
+        property real battery: 50
+        property real compassAzimuth: 0
+        property int batteryChargeState: 0
+        property int batteryChargerType: 0
+    }
+
+    QtObject {
+        id: burnInProtectionManager
+
+        property real widthOffset: 0
+        property real heightOffset: 0
+    }
+
+    QtObject {
+        id: compositor
+
+        signal displayAmbientEntered()
+        signal displayAmbientLeft()
+    }
 
     Settings {
         property alias round: roundCheckBox.checked
@@ -32,19 +56,19 @@ ApplicationWindow {
     }
 
     Binding {
-        target: Global
+        target: global
         property: "heartrate"
         value: heartRate.value
     }
 
     Binding {
-        target: Global
+        target: global
         property: "battery"
         value: batteryCharge.value
     }
 
     Binding {
-        target: Global
+        target: global
         property: "compassAzimuth"
         value: compassAzimuth.value
     }

--- a/watchface
+++ b/watchface
@@ -8,7 +8,7 @@
 #
 # Key features:
 # - Deploy watchfaces to an AsteroidOS watch
-# - Test watchfaces locally using qmlscene
+# - Test watchfaces locally using qml
 # - Clone existing watchfaces to create new ones
 # - Interactive menu systems (text-based and GUI)
 # - Automatic font configuration handling for custom fonts
@@ -56,7 +56,7 @@ version         display the version of this program and exit
 deploy WF       push the named watchface to the watch and activate it
 deployall       deploy all watchfaces
 clone WF NEWWF  clone the named watchface WF to new watchface NEWWF
-test WF         test the named watchface on the computer using qmlscene
+test WF         test the named watchface on the computer using qml
 raw QMLFILE     test a raw QML file without the standard directory structure
 
 EOF
@@ -106,6 +106,38 @@ TRANSPORT_ID=
 # Command execution state
 COMMAND=""                      # Command to execute (deploy, test, clone, etc.)
 declare -a COMMAND_ARGS=()      # Arguments for the command
+
+# Binary detection
+QML_BIN=""
+for bin in qml6 qml-qt6; do
+    if hash "${bin}" 2>/dev/null; then
+        QML_BIN="${bin}"
+        break
+    fi
+done
+
+# Watchface config helper
+function createWatchfaceConfig {
+    CONFIG_TMPDIR=$(mktemp -d -t asteroid-wf-XXXXXX)
+    mkdir -p "${CONFIG_TMPDIR}/WatchfaceConfig"
+
+    cat > "${CONFIG_TMPDIR}/WatchfaceConfig/qmldir" << EOF
+module WatchfaceConfig
+singleton WatchfaceConfig 1.0 WatchfaceConfig.qml
+EOF
+
+    cat > "${CONFIG_TMPDIR}/WatchfaceConfig/WatchfaceConfig.qml" << EOF
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    readonly property string watchfaceName: "$1"
+    readonly property string backgroundImage: "$2"
+    readonly property string backgroundRoundImage: "$3"
+    readonly property string relativeRootDir: "$4"
+}
+EOF
+}
 
 # ============================================================================
 # Core Communication Functions
@@ -322,7 +354,7 @@ function deleteTempFontconfig {
     rm -f "${temp_font_config}"
 }
 
-# Test a watchface locally using qmlscene
+# Test a watchface locally using qml
 # This function sets up the environment to test a watchface on the computer
 # without deploying it to the watch. It handles custom fonts by creating
 # temporary fontconfig configuration.
@@ -396,7 +428,14 @@ EOF
         WALLPAPER_ROUND="${SCRIPT_DIRPATH}/${WALLPAPER_ROUND}"
     fi
     
-    qmlscene "${sourcewatchfacename}" "${PWD}/${WALLPAPER}" "${PWD}/${WALLPAPER_ROUND}" "${sourcewatchfacedir}/usr/share/asteroid-launcher/watchfaces/" "${SCRIPT_DIRPATH}/loader.qml" -I "${SCRIPT_DIRPATH}/fake-components"
+    if [[ -z "${QML_BIN}" ]]; then
+        echo "Error: no Qt6 QML binary found (tried qml6, qml-qt6). Install qt6-declarative." >&2
+        exit 1
+    fi
+    createWatchfaceConfig "${sourcewatchfacename}" "${PWD}/${WALLPAPER}" "${PWD}/${WALLPAPER_ROUND}" "${sourcewatchfacedir}/usr/share/asteroid-launcher/watchfaces/"
+    trap "rm -rf '${CONFIG_TMPDIR}'" EXIT
+    QML_IMPORT_PATH="${SCRIPT_DIRPATH}/fake-components:${CONFIG_TMPDIR}" \
+        ${QML_BIN} "${SCRIPT_DIRPATH}/loader.qml"
     
     convertPreviews "${sourcewatchfacename}" "${sourcewatchfacedir}"
 }
@@ -457,7 +496,14 @@ EOF
         WALLPAPER_ROUND="${SCRIPT_DIRPATH}/${WALLPAPER_ROUND}"
     fi
     
-    qmlscene "${qml_name}" "${PWD}/${WALLPAPER}" "${PWD}/${WALLPAPER_ROUND}" "${qml_dir}/" "${SCRIPT_DIRPATH}/loader.qml" -I "${SCRIPT_DIRPATH}/fake-components"
+    if [[ -z "${QML_BIN}" ]]; then
+        echo "Error: no Qt6 QML binary found (tried qml6, qml-qt6). Install qt6-declarative." >&2
+        exit 1
+    fi
+    createWatchfaceConfig "${qml_name}" "${PWD}/${WALLPAPER}" "${PWD}/${WALLPAPER_ROUND}" "${qml_dir}/"
+    trap "rm -rf '${CONFIG_TMPDIR}'" EXIT
+    QML_IMPORT_PATH="${SCRIPT_DIRPATH}/fake-components:${CONFIG_TMPDIR}" \
+        ${QML_BIN} "${SCRIPT_DIRPATH}/loader.qml"
 }
 
 # Convert preview images for a watchface


### PR DESCRIPTION
Qt5 qmlscene is no longer the appropriate test runner for an AsteroidOS codebase targeting Qt6. This PR replaces it with the Qt6 qml6 binary and updates loader.qml and fake-components to match.

Qt5 support is dropped intentionally. The decision was discussed in Matrix and agreed by beroset.

**watchface script**
Detects the Qt6 QML binary at startup, trying qml6 then qml-qt6 to cover Arch Linux, Fedora and other distributions. Replaces the positional argument approach used with qmlscene: qml6 attempts to load every positional argument as a QML file, producing spurious engine errors for each non-QML argument. The fix is a createWatchfaceConfig helper that writes a temporary WatchfaceConfig singleton module to a mktemp directory and passes it via QML_IMPORT_PATH, leaving qml6 with only loader.qml as a file argument and producing a clean console.

**loader.qml**
Removes Qt5-only imports (Nemo.Mce 1.0, QtQuick.Dialogs 1.1, QtGraphicalEffects 1.12). Adds Qt5Compat.GraphicalEffects for OpacityMask. Replaces Qt.labs.settings with QtCore. Switches config reading from Qt.application.arguments indices to WatchfaceConfig singleton properties. Adds visible: true required by Qt6 ApplicationWindow. Adds inline stubs for global, burnInProtectionManager and compositor, which Qt5 qmlscene provided implicitly via root qmldir auto-loading.

**fake-components**
Adds org.asteroid.controls with an Icon stub and org.asteroid.utils with a DeviceSpecs stub. Qt6 qml6 no longer resolves these via system Qt5 paths. Lowercases Global to global in MceBatteryLevel, MceBatteryState and MceChargerType to match the id case change in loader.qml, which Qt6 enforces strictly.

Watchfaces still importing QtGraphicalEffects 1.x will show a module error in the test runner. That is a per-watchface issue addressed separately in the watchface polish pass, not a script or loader issue.