### PR TITLE
Refactor analog-lucida watchface for Qt6

### DIFF
--- a/analog-lucida/usr/share/asteroid-launcher/watchfaces/analog-lucida.qml
+++ b/analog-lucida/usr/share/asteroid-launcher/watchfaces/analog-lucida.qml
@@ -1,20 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
-//
 // Lucida — AsteroidOS watchface
-//
 // Painting on glass. 12 hairline hour indices + 60 minute dots.
 // A single italic Roman XII marks 12. Hour and minute hands are
 // hollow outlines — the wallpaper fills them; they are windows, not
 // objects. A single red hairline second hand with a small balance
 // ring is the only warm accent. No numerals, no date, no logo.
-//
 // Ambient: second hand + minute dots hidden. Just twelve indices,
 // two outlined hands, one italic XII.
-//
 // Font: EB Garamond (SIL OFL 1.1)
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root

--- a/analog-lucida/usr/share/asteroid-launcher/watchfaces/analog-lucida.qml
+++ b/analog-lucida/usr/share/asteroid-launcher/watchfaces/analog-lucida.qml
@@ -1,19 +1,18 @@
-/*
- * Lucida — AsteroidOS watchface
- *
- * Painting on glass. 12 hairline hour indices + 60 minute dots.
- * A single italic Roman XII marks 12. Hour and minute hands are
- * hollow outlines — the wallpaper fills them; they are windows, not
- * objects. A single red hairline second hand with a small balance
- * ring is the only warm accent. No numerals, no date, no logo.
- *
- * Ambient: second hand + minute dots hidden. Just twelve indices,
- * two outlined hands, one italic XII.
- *
- * Font: EB Garamond (SIL OFL 1.1)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// Lucida — AsteroidOS watchface
+//
+// Painting on glass. 12 hairline hour indices + 60 minute dots.
+// A single italic Roman XII marks 12. Hour and minute hands are
+// hollow outlines — the wallpaper fills them; they are windows, not
+// objects. A single red hairline second hand with a small balance
+// ring is the only warm accent. No numerals, no date, no logo.
+//
+// Ambient: second hand + minute dots hidden. Just twelve indices,
+// two outlined hands, one italic XII.
+//
+// Font: EB Garamond (SIL OFL 1.1)
 
 import QtQuick 2.15
 


### PR DESCRIPTION
## Summary

Recently written face, minimal changes needed.

## Commits

- **Convert design comment** — move below SPDX header, reformat from block to line comments
- **Qt6 import fix** — drop QtQuick version suffix

## Testing

Tested on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): smooth hand sweep, AoD.