### PR TITLE
Refactor analog-magnetic-field watchface for Qt6

### DIFF
--- a/analog-magnetic-field/usr/share/asteroid-launcher/watchfaces/analog-magnetic-field.qml
+++ b/analog-magnetic-field/usr/share/asteroid-launcher/watchfaces/analog-magnetic-field.qml
@@ -1,15 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
-//
 // Magnetic Field — AsteroidOS watchface
-//
 // Iron-filings field in three rings, each stroke tilted toward the
 // hour-hand angle with influence decaying by cos(angular distance).
 // Minute hand sweeps smoothly via 16 ms timer.
-//
 // Font: Space Mono (OFL)
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root

--- a/analog-magnetic-field/usr/share/asteroid-launcher/watchfaces/analog-magnetic-field.qml
+++ b/analog-magnetic-field/usr/share/asteroid-launcher/watchfaces/analog-magnetic-field.qml
@@ -1,14 +1,13 @@
-/*
- * Magnetic Field — AsteroidOS watchface
- *
- * Iron-filings field in three rings, each stroke tilted toward the
- * hour-hand angle with influence decaying by cos(angular distance).
- * Minute hand sweeps smoothly via 16 ms timer.
- *
- * Font: Space Mono (OFL)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// Magnetic Field — AsteroidOS watchface
+//
+// Iron-filings field in three rings, each stroke tilted toward the
+// hour-hand angle with influence decaying by cos(angular distance).
+// Minute hand sweeps smoothly via 16 ms timer.
+//
+// Font: Space Mono (OFL)
 
 import QtQuick 2.15
 


### PR DESCRIPTION
## Summary

Recently written face, minimal changes needed.

## Commits

- **Convert design comment** — move below SPDX header, reformat from block to line comments
- **Qt6 import fix** — drop QtQuick version suffix

## Testing

Tested on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): smooth minute sweep, field repaint on AoD transition.