### PR TITLE
Refactor analog-moega-sushimaster watchface for Qt6

### DIFF
--- a/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
+++ b/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
@@ -20,7 +20,9 @@ Item {
     Item {
         id: faceBox
 
-        anchors.fill: parent
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
         layer.enabled: true
 
         Image {
@@ -75,7 +77,9 @@ Item {
         id: handBox
 
         z: 3
-        anchors.fill: parent
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
         Image {
             id: hourSVG

--- a/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
+++ b/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
@@ -149,14 +149,4 @@ Item {
 
     }
 
-    Connections {
-        function onTimeChanged() {
-            if (!visible)
-                return ;
-
-        }
-
-        target: wallClock
-    }
-
 }

--- a/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
+++ b/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.15

--- a/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
+++ b/analog-moega-sushimaster/usr/share/asteroid-launcher/watchfaces/analog-moega-sushimaster.qml
@@ -6,8 +6,8 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root
@@ -86,8 +86,8 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
                 angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
             }
 
@@ -111,8 +111,8 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
                 angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
             }
 
@@ -134,21 +134,11 @@ Item {
             visible: !displayAmbient
             source: imgPath + "second.svg"
             anchors.fill: parent
-            layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
                 angle: (wallClock.time.getSeconds() * 6)
-            }
-
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 4
-                verticalOffset: 4
-                radius: 8
-                samples: 9
-                color: Qt.rgba(0, 0, 0, 0.3)
             }
 
         }


### PR DESCRIPTION
## Summary

Full polish pass bringing SPDX header, Qt6 correctness, square geometry, and dead code removal.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 correctness fixes** — fix import module name and versions, Rotation origins to item ids, remove layer from 60fps second hand
- **Fix square geometry** — faceBox and handBox changed from anchors.fill to explicit square sizing, correctly centred on non-square panels
- **Remove empty Connections block** — onTimeChanged contained only an early return; all hands use declarative bindings

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): tick orbit, hand rotation, AoD.

## Notes

Outer screen-filling Item kept on purpose — system root; faceBox and handBox are the square layout containers.