### PR TITLE
Refactor analog-nort watchface for Qt6

### DIFF
--- a/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
+++ b/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.9

--- a/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
+++ b/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
@@ -6,8 +6,8 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root
@@ -104,16 +104,17 @@ Item {
     }
 
     Connections {
-        target: wallClock
-        onTimeChanged: {
+        function onTimeChanged() {
             if (!visible)
-                return ;
+                return;
 
             var h = wallClock.time.getHours();
             var min = wallClock.time.getMinutes();
             hourRot.angle = h * 30 + min * 0.5;
             minuteRot.angle = min * 6 + (wallClock.time.getSeconds() * 6 / 60);
         }
+
+        target: wallClock
     }
 
 }

--- a/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
+++ b/analog-nort/usr/share/asteroid-launcher/watchfaces/analog-nort.qml
@@ -13,7 +13,9 @@ Item {
     id: root
 
     property string imgPath: "../watchfaces-img/analog-nort-"
+    property real maxSize: Math.min(width, height)
 
+    anchors.fill: parent
     Component.onCompleted: {
         var h = wallClock.time.getHours();
         var min = wallClock.time.getMinutes();
@@ -21,74 +23,83 @@ Item {
         minuteRot.angle = min * 6 + (wallClock.time.getSeconds() * 6 / 60);
     }
 
-    Image {
-        id: hourSVG
+    Item {
+        id: faceBox
 
-        anchors.centerIn: root
-        source: imgPath + "hour.svg"
-        width: root.width
-        height: root.height
-        layer.enabled: true
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
-        transform: Rotation {
-            id: hourRot
+        Image {
+            id: hourSVG
 
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            anchors.centerIn: parent
+            source: imgPath + "hour.svg"
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
+
+            transform: Rotation {
+                id: hourRot
+
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+            }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: 8
+                samples: 9
+                color: "#66fbfb"
+            }
+
         }
 
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 0
-            verticalOffset: 0
-            radius: 8
-            samples: 9
-            color: "#66fbfb"
+        Image {
+            id: minuteSVG
+
+            anchors.centerIn: parent
+            source: imgPath + "minute.svg"
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
+
+            transform: Rotation {
+                id: minuteRot
+
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+            }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: 8
+                samples: 9
+                color: "#66fbfb"
+            }
+
         }
 
-    }
+        Image {
+            id: secondSVG
 
-    Image {
-        id: minuteSVG
+            anchors.centerIn: parent
+            source: imgPath + "second.svg"
+            width: parent.width
+            height: parent.width
+            visible: !displayAmbient
 
-        anchors.centerIn: root
-        source: imgPath + "minute.svg"
-        width: root.width
-        height: root.height
-        layer.enabled: true
+            transform: Rotation {
+                id: secondRot
 
-        transform: Rotation {
-            id: minuteRot
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+            }
 
-            origin.x: root.width / 2
-            origin.y: root.height / 2
-        }
-
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 0
-            verticalOffset: 0
-            radius: 8
-            samples: 9
-            color: "#66fbfb"
-        }
-
-    }
-
-    Image {
-        id: secondSVG
-
-        anchors.centerIn: root
-        source: imgPath + "second.svg"
-        width: root.width
-        height: root.height
-        visible: !displayAmbient
-
-        transform: Rotation {
-            id: secondRot
-
-            origin.x: root.width / 2
-            origin.y: root.height / 2
         }
 
     }
@@ -106,7 +117,7 @@ Item {
     Connections {
         function onTimeChanged() {
             if (!visible)
-                return;
+                return ;
 
             var h = wallClock.time.getHours();
             var min = wallClock.time.getMinutes();


### PR DESCRIPTION
## Summary

The recommended starter template for new watchface contributors.
Full polish pass ensuring the patterns beginners copy are correct and up to current standards.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX   one-liner format
- **Qt6 correctness fixes** — import module rename, version drops,   Connections to function handler syntax
- **Square geometry and Rotation origins** — faceBox container,   anchors.fill on root, item id origins on all three hand transforms

## Testing

Tested on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular face geometry, smooth second sweep, Tron glow on hour and minute hands, AoD.

## Notes

As the project's recommended fork base for new contributors, correct patterns here matter beyond this face alone. Timer and Connections remain at root level outside faceBox as they have no geometry
dependency.