### PR TITLE
Refactor analog-rings watchface for Qt6

### DIFF
--- a/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
+++ b/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
@@ -6,8 +6,8 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
+import QtQuick
+import QtQuick.Shapes
 
 Item {
     id: root

--- a/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
+++ b/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
@@ -12,22 +12,32 @@ import QtQuick.Shapes
 Item {
     id: root
 
-    Component.onCompleted: {
-        var h = wallClock.time.getHours();
-        var min = wallClock.time.getMinutes();
-        var rotH = (h - 3 + min / 60) / 12;
-        var rotM = (min - 15) / 60;
-        var cx = root.width / 2;
-        var cy = root.height / 2;
-        var dotR = root.width / 5.75 / 2;
-        minuteDot.x = cx + Math.cos(rotM * 2 * Math.PI) * root.width * 0.36 - dotR;
-        minuteDot.y = cy + Math.sin(rotM * 2 * Math.PI) * root.width * 0.36 - dotR;
-        hourDot.x = cx + Math.cos(rotH * 2 * Math.PI) * root.width * 0.185 - dotR;
-        hourDot.y = cy + Math.sin(rotH * 2 * Math.PI) * root.width * 0.185 - dotR;
-        hourDisplay.x = cx - hourDisplay.width / 2 - root.height * 0.0015 + Math.cos(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.height * 0.007);
-        hourDisplay.y = cy - hourDisplay.height / 2 + Math.sin(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.height * 0.007) - root.height * 0.006;
-        minuteDisplay.x = cx - minuteDisplay.width / 2 - root.height * 0.0015 + Math.cos(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.height * 0.007);
-        minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.height * 0.007) - root.height * 0.006;
+    property real maxSize: Math.min(width, height)
+    readonly property real fontBaselineNudge: maxSize * 0.011
+
+    anchors.fill: parent
+
+    Timer {
+        interval: 1
+        repeat: false
+        running: true
+        onTriggered: {
+            var h = wallClock.time.getHours();
+            var min = wallClock.time.getMinutes();
+            var rotH = (h - 3 + min / 60) / 12;
+            var rotM = (min - 15) / 60;
+            var cx = root.width / 2;
+            var cy = root.height / 2;
+            var dotR = root.maxSize / 5.75 / 2;
+            minuteDot.x = cx + Math.cos(rotM * 2 * Math.PI) * root.maxSize * 0.36 - dotR;
+            minuteDot.y = cy + Math.sin(rotM * 2 * Math.PI) * root.maxSize * 0.36 - dotR;
+            hourDot.x = cx + Math.cos(rotH * 2 * Math.PI) * root.maxSize * 0.185 - dotR;
+            hourDot.y = cy + Math.sin(rotH * 2 * Math.PI) * root.maxSize * 0.185 - dotR;
+            hourDisplay.x = cx - hourDisplay.width / 2 - root.maxSize * 0.0015 + Math.cos(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.maxSize * 0.007);
+            hourDisplay.y = cy - hourDisplay.height / 2 + Math.sin(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.maxSize * 0.007) - root.maxSize * 0.006 + root.fontBaselineNudge;
+            minuteDisplay.x = cx - minuteDisplay.width / 2 - root.maxSize * 0.0015 + Math.cos(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.maxSize * 0.007);
+            minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.maxSize * 0.007) - root.maxSize * 0.006 + root.fontBaselineNudge;
+        }
     }
 
     Image {
@@ -35,25 +45,27 @@ Item {
 
         source: "../watchfaces-img/asteroid-logo.svg"
         anchors.centerIn: parent
-        width: parent.width / 5.7
-        height: parent.height / 5.7
+        width: root.maxSize / 5.7
+        height: root.maxSize / 5.7
     }
 
     // Minute ring background track
     Shape {
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
         ShapePath {
             strokeColor: Qt.rgba(0, 0, 0, 0.5)
-            strokeWidth: parent.width / 80
+            strokeWidth: root.maxSize / 80
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
 
             PathAngleArc {
-                centerX: parent.width / 2
-                centerY: parent.height / 2
-                radiusX: parent.width / 2.75
-                radiusY: parent.height / 2.75
+                centerX: root.maxSize / 2
+                centerY: root.maxSize / 2
+                radiusX: root.maxSize / 2.75
+                radiusY: root.maxSize / 2.75
                 startAngle: -90
                 sweepAngle: 360
             }
@@ -64,19 +76,21 @@ Item {
 
     // Minute progress arc — sweepAngle binding drives redraw automatically
     Shape {
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
         ShapePath {
             strokeColor: Qt.rgba(1, 1, 1, 0.7)
-            strokeWidth: parent.width / 20
+            strokeWidth: root.maxSize / 20
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
 
             PathAngleArc {
-                centerX: parent.width / 2
-                centerY: parent.height / 2
-                radiusX: parent.width / 2.75
-                radiusY: parent.height / 2.75
+                centerX: root.maxSize / 2
+                centerY: root.maxSize / 2
+                radiusX: root.maxSize / 2.75
+                radiusY: root.maxSize / 2.75
                 startAngle: -90
                 sweepAngle: (wallClock.time.getMinutes() / 60) * 360
             }
@@ -85,31 +99,23 @@ Item {
 
     }
 
-    // Dot at minute hand tip — positioned imperatively from Connections
-    Rectangle {
-        id: minuteDot
-
-        width: root.width / 5.75
-        height: width
-        radius: width / 2
-        color: Qt.rgba(0.184, 0.184, 0.184, 0.9)
-    }
-
     // Hour ring background track
     Shape {
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
         ShapePath {
             strokeColor: Qt.rgba(0, 0, 0, 0.5)
-            strokeWidth: parent.width / 80
+            strokeWidth: root.maxSize / 80
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
 
             PathAngleArc {
-                centerX: parent.width / 2
-                centerY: parent.height / 2
-                radiusX: parent.width / 5.3
-                radiusY: parent.height / 5.3
+                centerX: root.maxSize / 2
+                centerY: root.maxSize / 2
+                radiusX: root.maxSize / 5.3
+                radiusY: root.maxSize / 5.3
                 startAngle: -90
                 sweepAngle: 360
             }
@@ -120,19 +126,21 @@ Item {
 
     // Hour progress arc — 0° at 12:00, full 360° at 12:00 again
     Shape {
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
         ShapePath {
             strokeColor: Qt.rgba(1, 1, 1, 0.7)
-            strokeWidth: parent.width / 20
+            strokeWidth: root.maxSize / 20
             fillColor: "transparent"
             capStyle: ShapePath.RoundCap
 
             PathAngleArc {
-                centerX: parent.width / 2
-                centerY: parent.height / 2
-                radiusX: parent.width / 5.3
-                radiusY: parent.height / 5.3
+                centerX: root.maxSize / 2
+                centerY: root.maxSize / 2
+                radiusX: root.maxSize / 5.3
+                radiusY: root.maxSize / 5.3
                 startAngle: -90
                 sweepAngle: ((wallClock.time.getHours() % 12) * 60 + wallClock.time.getMinutes()) / 720 * 360
             }
@@ -145,7 +153,7 @@ Item {
     Rectangle {
         id: hourDot
 
-        width: root.width / 5.75
+        width: root.maxSize / 5.75
         height: width
         radius: width / 2
         color: Qt.rgba(0.184, 0.184, 0.184, 0.9)
@@ -158,17 +166,27 @@ Item {
         text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "<b>hh</b> ap").slice(0, 9) : wallClock.time.toLocaleString(Qt.locale(), "<b>HH</b>")
 
         font {
-            pixelSize: parent.height / 8
+            pixelSize: root.maxSize / 8
             family: "SlimSans"
             styleName: "Bold"
         }
 
     }
 
+    // Dot at minute hand tip — positioned imperatively from Timer and Connections
+    Rectangle {
+        id: minuteDot
+
+        width: root.maxSize / 5.75
+        height: width
+        radius: width / 2
+        color: Qt.rgba(0.184, 0.184, 0.184, 0.9)
+    }
+
     Text {
         id: minuteDisplay
 
-        font.pixelSize: parent.height / 8
+        font.pixelSize: root.maxSize / 8
         font.family: "SlimSans"
         color: "white"
         style: Text.Outline
@@ -187,15 +205,15 @@ Item {
             var rotM = (min - 15) / 60;
             var cx = root.width / 2;
             var cy = root.height / 2;
-            var dotR = root.width / 5.75 / 2;
-            minuteDot.x = cx + Math.cos(rotM * 2 * Math.PI) * root.width * 0.36 - dotR;
-            minuteDot.y = cy + Math.sin(rotM * 2 * Math.PI) * root.width * 0.36 - dotR;
-            hourDot.x = cx + Math.cos(rotH * 2 * Math.PI) * root.width * 0.185 - dotR;
-            hourDot.y = cy + Math.sin(rotH * 2 * Math.PI) * root.width * 0.185 - dotR;
-            hourDisplay.x = cx - hourDisplay.width / 2 - root.height * 0.0015 + Math.cos(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.height * 0.007);
-            hourDisplay.y = cy - hourDisplay.height / 2 + Math.sin(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.height * 0.007) - root.height * 0.006;
-            minuteDisplay.x = cx - minuteDisplay.width / 2 - root.height * 0.0015 + Math.cos(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.height * 0.007);
-            minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.height * 0.007) - root.height * 0.006;
+            var dotR = root.maxSize / 5.75 / 2;
+            minuteDot.x = cx + Math.cos(rotM * 2 * Math.PI) * root.maxSize * 0.36 - dotR;
+            minuteDot.y = cy + Math.sin(rotM * 2 * Math.PI) * root.maxSize * 0.36 - dotR;
+            hourDot.x = cx + Math.cos(rotH * 2 * Math.PI) * root.maxSize * 0.185 - dotR;
+            hourDot.y = cy + Math.sin(rotH * 2 * Math.PI) * root.maxSize * 0.185 - dotR;
+            hourDisplay.x = cx - hourDisplay.width / 2 - root.maxSize * 0.0015 + Math.cos(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.maxSize * 0.007);
+            hourDisplay.y = cy - hourDisplay.height / 2 + Math.sin(rotH * 2 * Math.PI) * (hourDisplay.height * 1.32 - root.maxSize * 0.007) - root.maxSize * 0.006 + root.fontBaselineNudge;
+            minuteDisplay.x = cx - minuteDisplay.width / 2 - root.maxSize * 0.0015 + Math.cos(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.maxSize * 0.007);
+            minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * (minuteDisplay.height * 2.535 - root.maxSize * 0.007) - root.maxSize * 0.006 + root.fontBaselineNudge;
         }
 
         target: wallClock

--- a/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
+++ b/analog-rings/usr/share/asteroid-launcher/watchfaces/analog-rings.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15


### PR DESCRIPTION
## Summary

Early sphere-hand interpretation using Shape arcs and imperatively positioned dots and text. The unique imperative positioning architecture required more involved geometry work than typical faces to achieve correct rendering on beluga.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2018
- **Qt6 import fix** — drop version suffixes from QtQuick and QtQuick.Shapes
- **Add square geometry guard** — Shape items given explicit square sizing via root.maxSize; Component.onCompleted replaced with a one-shot Timer to avoid zero-dimension layout race; orbit radii, dot sizing, and font pixelSize unified to root.maxSize; Qt6 font bounding box nudge applied to glyph y positions to centre them visually within their dot

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular arc geometry, dots on arcs, glyphs centred in dots, AoD.

## Notes

The dot and text items remain as direct children of root rather than inside a faceBox. Their imperative x/y positioning uses root.width and root.height to find the panel centre, which is the same point as the face centre on all screen shapes. Placing them inside faceBox would shift their coordinate origin and break the positioning math.