### PR TITLE
Refactor analog-silly-walks watchface for Qt6

### DIFF
--- a/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
+++ b/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
@@ -14,7 +14,9 @@ Item {
     property string currentColor: ""
     property string userColor: ""
     property string imgPath: "../watchfaces-img/analog-silly-walks-"
+    property real maxSize: Math.min(width, height)
 
+    anchors.fill: parent
     Component.onCompleted: {
         var h = wallClock.time.getHours();
         var min = wallClock.time.getMinutes();
@@ -23,174 +25,179 @@ Item {
         minuteRot.angle = min * 6 + sec * 6 / 60;
     }
 
-    Repeater {
-        model: 12
+    Item {
+        id: faceBox
 
-        Text {
-            property real rotM: (index * 5 - 15) / 60
-            property real centerX: root.width / 2 - width / 2
-            property real centerY: root.height / 2 - height / 2
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
-            z: 1
-            x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.383
-            y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.383
-            color: "white"
-            text: index
-            opacity: index === 0 ? 0 : 1
-            state: currentColor
+        Repeater {
+            model: 12
 
-            font {
-                pixelSize: root.height * 0.15
-                family: "Varieté"
-            }
+            Text {
+                property real rotM: (index * 5 - 15) / 60
+                property real centerX: root.maxSize / 2 - width / 2
+                property real centerY: root.maxSize / 2 - height / 2
 
-            states: State {
-                name: "black"
+                z: 1
+                x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.383
+                y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.383
+                color: "white"
+                text: index
+                opacity: index === 0 ? 0 : 1
+                state: currentColor
 
-                PropertyChanges {
-                    target: parent
-                    color: "black"
+                font {
+                    pixelSize: root.maxSize * 0.155
+                    family: "Varieté"
                 }
 
-            }
+                states: State {
+                    name: "black"
 
-            transitions: Transition {
-                from: ""
-                to: "black"
-                reversible: true
+                    PropertyChanges {
+                        target: parent
+                        color: "black"
+                    }
 
-                ColorAnimation {
-                    duration: 300
                 }
 
-            }
+                transitions: Transition {
+                    from: ""
+                    to: "black"
+                    reversible: true
 
-        }
+                    ColorAnimation {
+                        duration: 300
+                    }
 
-    }
-
-    Repeater {
-        model: 12
-
-        Text {
-            property real rotM: (index * 5 - 15) / 60
-            property real centerX: root.width / 2 - width / 2
-            property real centerY: root.height / 2 - height / 2
-
-            z: 0
-            x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.37
-            y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.37
-            color: "black"
-            text: index
-            opacity: index === 0 ? 0 : 1
-            state: currentColor
-
-            font {
-                pixelSize: root.height * 0.155
-                family: "Varieté"
-            }
-
-            states: State {
-                name: "black"
-
-                PropertyChanges {
-                    target: parent
-                    color: "white"
-                }
-
-            }
-
-            transitions: Transition {
-                from: ""
-                to: "black"
-                reversible: true
-
-                ColorAnimation {
-                    duration: 300
                 }
 
             }
 
         }
 
-    }
+        Repeater {
+            model: 12
 
-    Image {
-        id: backgound
+            Text {
+                property real rotM: (index * 5 - 15) / 60
+                property real centerX: root.maxSize / 2 - width / 2
+                property real centerY: root.maxSize / 2 - height / 2
 
-        z: 2
-        source: !displayAmbient ? imgPath + "bg.svg" : imgPath + "bg-white.svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
-    }
+                z: 0
+                x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.37
+                y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.37
+                color: "black"
+                text: index
+                opacity: index === 0 ? 0 : 1
+                state: currentColor
 
-    Image {
-        id: hourSVG
+                font {
+                    pixelSize: root.maxSize * 0.15
+                    family: "Varieté"
+                }
 
-        z: 2
-        source: !displayAmbient ? imgPath + "hour.svg" : imgPath + "hour-white.svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
+                states: State {
+                    name: "black"
 
-        transform: Rotation {
-            id: hourRot
+                    PropertyChanges {
+                        target: parent
+                        color: "white"
+                    }
 
-            origin.x: hourSVG.width / 2
-            origin.y: hourSVG.height / 2
+                }
+
+                transitions: Transition {
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 300
+                    }
+
+                }
+
+            }
+
         }
 
-    }
+        Image {
+            id: backgound
 
-    Image {
-        id: minuteSVG
-
-        z: 3
-        source: !displayAmbient ? imgPath + "minute.svg" : imgPath + "minute-white.svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
-
-        transform: Rotation {
-            id: minuteRot
-
-            origin.x: minuteSVG.width / 2
-            origin.y: minuteSVG.height / 2
+            source: !displayAmbient ? imgPath + "bg.svg" : imgPath + "bg-white.svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
         }
 
-    }
+        Image {
+            id: hourSVG
 
-    Image {
-        id: secondSVG
+            source: !displayAmbient ? imgPath + "hour.svg" : imgPath + "hour-white.svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
 
-        property int toggle: 1
+            transform: Rotation {
+                id: hourRot
 
-        z: 4
-        visible: !displayAmbient
-        source: imgPath + "second.svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+            }
 
-        MouseArea {
-            anchors.fill: parent
-            onDoubleClicked: {
-                if (secondSVG.toggle === 1) {
-                    currentColor = "black";
-                    secondSVG.toggle = 0;
-                } else {
-                    currentColor = "";
-                    secondSVG.toggle = 1;
+        }
+
+        Image {
+            id: minuteSVG
+
+            source: !displayAmbient ? imgPath + "minute.svg" : imgPath + "minute-white.svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
+
+            transform: Rotation {
+                id: minuteRot
+
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+            }
+
+        }
+
+        Image {
+            id: secondSVG
+
+            property int toggle: 1
+
+            visible: !displayAmbient
+            source: imgPath + "second.svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
+
+            MouseArea {
+                anchors.fill: parent
+                onDoubleClicked: {
+                    if (secondSVG.toggle === 1) {
+                        currentColor = "black";
+                        secondSVG.toggle = 0;
+                    } else {
+                        currentColor = "";
+                        secondSVG.toggle = 1;
+                    }
                 }
             }
-        }
 
-        transform: Rotation {
-            id: secondRot
+            transform: Rotation {
+                id: secondRot
 
-            origin.x: secondSVG.width / 2
-            origin.y: secondSVG.height / 2
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+            }
+
         }
 
     }
@@ -209,7 +216,7 @@ Item {
     Connections {
         function onTimeChanged() {
             if (!visible)
-                return;
+                return ;
 
             var h = wallClock.time.getHours();
             var min = wallClock.time.getMinutes();

--- a/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
+++ b/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
@@ -137,8 +137,8 @@ Item {
         transform: Rotation {
             id: hourRot
 
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: hourSVG.width / 2
+            origin.y: hourSVG.height / 2
         }
 
     }
@@ -155,8 +155,8 @@ Item {
         transform: Rotation {
             id: minuteRot
 
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: minuteSVG.width / 2
+            origin.y: minuteSVG.height / 2
         }
 
     }
@@ -189,8 +189,8 @@ Item {
         transform: Rotation {
             id: secondRot
 
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: secondSVG.width / 2
+            origin.y: secondSVG.height / 2
         }
 
     }

--- a/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
+++ b/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2021 - Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.9
 

--- a/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
+++ b/analog-silly-walks/usr/share/asteroid-launcher/watchfaces/analog-silly-walks.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     id: root
@@ -207,10 +207,9 @@ Item {
     }
 
     Connections {
-        target: wallClock
-        onTimeChanged: {
+        function onTimeChanged() {
             if (!visible)
-                return ;
+                return;
 
             var h = wallClock.time.getHours();
             var min = wallClock.time.getMinutes();
@@ -218,6 +217,8 @@ Item {
             hourRot.angle = h * 30 + min * 0.5;
             minuteRot.angle = min * 6 + sec * 6 / 60;
         }
+
+        target: wallClock
     }
 
     Connections {


### PR DESCRIPTION
## Summary

Monty Python silly walks theme with a continuous smooth second hand sweep and a comical two-layer drop shadow on the hour numerals. Full polish pass — colour toggle state machine and ambient preservation logic left intact pending future migration to watchface settings.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate erroneous 2026 entry into correct 2021 moWerk line
- **Qt6 correctness fixes** — drop import version suffix, convert wallClock Connections to function handler syntax
- **Fix Rotation transform origins** — reference item ids instead of root in all three hand transforms
- **Add square geometry guard** — faceBox container, maxSize property, font sizes switched to root.maxSize; note z values on numeral Repeaters are intentional and preserved to maintain the two-layer shadow render order

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular face geometry, numeral shadow effect, smooth second sweep, colour toggle on double-tap, ambient state preservation, AoD.

## Notes

The two numeral Repeaters carry intentional z values. The shadow layer (z: 0, black, slightly larger) must render behind the white layer (z: 1). Without explicit z values declaration order would reverse this, flattening the comical drop shadow effect.