### PR TITLE
Refactor analog-tactical watchface for Qt6

### DIFF
--- a/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
+++ b/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
@@ -1,33 +1,15 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-/*
- * This watchface is based on the official analog watchface and analog-precision.
- * Main attraction of this watchface is the seconds arm advancing over the center
- * of the clock. Also the hour and minute arms got an advanced outer and center part.
- * Overall design is a recreation of vintage 70s BRAUN clock arms with thick strokes.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// analog-tactical — inspired by analog-precision by Mario Kicherer
+// Recreation of vintage 70s BRAUN clock arms with thick strokes.
+// Main attraction is the seconds arm advancing over the clock centre.
+// Hour and minute arms feature distinct outer and centre segments.
 
 import QtQuick 2.9
 

--- a/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
+++ b/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
@@ -11,7 +11,7 @@
 // Main attraction is the seconds arm advancing over the clock centre.
 // Hour and minute arms feature distinct outer and centre segments.
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     Component.onCompleted: {

--- a/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
+++ b/analog-tactical/usr/share/asteroid-launcher/watchfaces/analog-tactical.qml
@@ -14,6 +14,11 @@
 import QtQuick
 
 Item {
+    id: root
+
+    property real maxSize: Math.min(width, height)
+
+    anchors.fill: parent
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         var minute = wallClock.time.getMinutes();
@@ -31,200 +36,209 @@ Item {
         dateCanvas.requestPaint();
     }
 
-    // Hour strokes — static, paints once only
-    Canvas {
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.lineCap = "round";
-            ctx.lineWidth = parent.width * 0.1;
-            ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.65);
-            ctx.translate(parent.width / 2, parent.height / 2);
-            for (var i = 0; i < 12; i++) {
-                ctx.beginPath();
-                ctx.moveTo(0, height * 0.398);
-                ctx.lineTo(0, height * 0.3981);
-                ctx.stroke();
-                ctx.rotate(Math.PI / 6);
+    Item {
+        id: faceBox
+
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
+
+        // Hour strokes — static, paints once only
+        Canvas {
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.lineCap = "round";
+                ctx.lineWidth = parent.width * 0.1;
+                ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.65);
+                ctx.translate(parent.width / 2, parent.height / 2);
+                for (var i = 0; i < 12; i++) {
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.398);
+                    ctx.lineTo(0, height * 0.3981);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 6);
+                }
             }
         }
-    }
 
-    // Number strokes — static, paints once only
-    Canvas {
-        property real voffset: -parent.height * 0.015
-        property real hoffset: -parent.height * 0.003
+        // Number strokes — static, paints once only
+        Canvas {
+            property real voffset: -parent.height * 0.015
+            property real hoffset: -parent.height * 0.003
 
-        anchors.fill: parent
-        antialiasing: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.fillStyle = Qt.rgba(1, 1, 1, 0.85);
-            ctx.textAlign = "center";
-            ctx.textBaseline = "middle";
-            ctx.translate(parent.width / 2, parent.height / 2);
-            for (var i = 1; i < 13; i++) {
+            anchors.fill: parent
+            antialiasing: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.fillStyle = Qt.rgba(1, 1, 1, 0.85);
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.translate(parent.width / 2, parent.height / 2);
+                for (var i = 1; i < 13; i++) {
+                    ctx.beginPath();
+                    ctx.font = "99 " + height / 13 + "px Fyodor";
+                    ctx.fillText(i, i === 10 ? Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.402 - hoffset : i === 1 || i === 12 ? Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.39 - hoffset : Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.398 - hoffset, (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * 0.398) - voffset);
+                    ctx.closePath();
+                }
+            }
+        }
+
+        Canvas {
+            id: hourHand
+
+            property int hour: 0
+            property int minute: 0
+            property real rotH: (hour - 3 + minute / 60) / 12
+
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
                 ctx.beginPath();
-                ctx.font = "99 " + height / 13 + "px Fyodor";
-                ctx.fillText(i, i === 10 ? Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.402 - hoffset : i === 1 || i === 12 ? Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.39 - hoffset : Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.398 - hoffset, (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * 0.398) - voffset);
+                ctx.lineWidth = parent.width * 0.03;
+                ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.0494, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.0494);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.0855, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.0855);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineCap = "round";
+                ctx.lineWidth = parent.width * 0.057;
+                ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.11, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.11);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.267, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.267);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineWidth = parent.width * 0.033;
+                ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.112, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.112);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.265, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.265);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineWidth = parent.width * 0.008;
+                ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.05);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.122);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineWidth = parent.width * 0.015;
+                ctx.strokeStyle = Qt.rgba(0.945, 0.769, 0.059, 1);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.113, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.113);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.264, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.264);
+                ctx.stroke();
                 ctx.closePath();
             }
         }
-    }
 
-    Canvas {
-        id: hourHand
+        Canvas {
+            id: minuteHand
 
-        property int hour: 0
-        property int minute: 0
-        property real rotH: (hour - 3 + minute / 60) / 12
+            property int minute: 0
+            property real rotM: (minute - 15) / 60
 
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width * 0.03;
-            ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.0494, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.0494);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.0855, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.0855);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.lineCap = "round";
-            ctx.lineWidth = parent.width * 0.057;
-            ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.11, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.11);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.267, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.267);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width * 0.033;
-            ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.112, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.112);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.265, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.265);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width * 0.008;
-            ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.05);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.122);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width * 0.015;
-            ctx.strokeStyle = Qt.rgba(0.945, 0.769, 0.059, 1);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.113, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.113);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * 0.264, parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * 0.264);
-            ctx.stroke();
-            ctx.closePath();
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.beginPath();
+                ctx.lineWidth = parent.width * 0.03;
+                ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.0494, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.0494);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.098, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.098);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineCap = "round";
+                ctx.lineWidth = parent.width * 0.052;
+                ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
+                ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.12, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.12);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.355, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.355);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.lineWidth = parent.width * 0.028;
+                ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
+                ctx.beginPath();
+                ctx.shadowBlur = 0;
+                ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.122);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.357, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.357);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.shadowBlur = 0;
+                ctx.lineWidth = parent.width * 0.008;
+                ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.05);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.122);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.strokeStyle = Qt.rgba(0.902, 0.494, 0.133, 1);
+                ctx.lineWidth = parent.width * 0.01;
+                ctx.beginPath();
+                ctx.shadowBlur = 0;
+                ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.123, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.123);
+                ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.356, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.356);
+                ctx.stroke();
+                ctx.closePath();
+            }
         }
-    }
 
-    Canvas {
-        id: minuteHand
+        Canvas {
+            id: secondHand
 
-        property int minute: 0
-        property real rotM: (minute - 15) / 60
+            property int second: 0
 
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width * 0.03;
-            ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.0494, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.0494);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.098, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.098);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.lineCap = "round";
-            ctx.lineWidth = parent.width * 0.052;
-            ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.75);
-            ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.12, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.12);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.355, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.355);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.lineWidth = parent.width * 0.028;
-            ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
-            ctx.beginPath();
-            ctx.shadowBlur = 0;
-            ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.122);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.357, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.357);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.shadowBlur = 0;
-            ctx.lineWidth = parent.width * 0.008;
-            ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.05);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.122, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.122);
-            ctx.stroke();
-            ctx.closePath();
-            ctx.strokeStyle = Qt.rgba(0.902, 0.494, 0.133, 1);
-            ctx.lineWidth = parent.width * 0.01;
-            ctx.beginPath();
-            ctx.shadowBlur = 0;
-            ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.123, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.123);
-            ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * 0.356, parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * 0.356);
-            ctx.stroke();
-            ctx.closePath();
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0, 0, 0, 0.7);
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 1;
+                ctx.strokeStyle = Qt.rgba(0.871, 0.165, 0.102, 1);
+                ctx.lineWidth = parent.height * 0.006;
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.moveTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.05);
+                ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.325, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.325);
+                ctx.stroke();
+                ctx.closePath();
+            }
         }
-    }
 
-    Canvas {
-        id: secondHand
+        Canvas {
+            id: dateCanvas
 
-        property int second: 0
+            property int date: 0
+            property string dateText: ""
 
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.shadowColor = Qt.rgba(0, 0, 0, 0.7);
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 1;
-            ctx.strokeStyle = Qt.rgba(0.871, 0.165, 0.102, 1);
-            ctx.lineWidth = parent.height * 0.006;
-            ctx.closePath();
-            ctx.beginPath();
-            ctx.moveTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.05, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.05);
-            ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.325, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.325);
-            ctx.stroke();
-            ctx.closePath();
+            anchors.fill: parent
+            antialiasing: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.beginPath();
+                ctx.fillStyle = Qt.rgba(0, 0, 0, 0.75);
+                ctx.arc(parent.width / 2, parent.height / 2, parent.height * 0.056, 0, 2 * Math.PI, false);
+                ctx.fill();
+                ctx.closePath();
+                ctx.fillStyle = "white";
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.font = "99 " + height / 14 + "px Noto Sans";
+                ctx.fillText(dateText, width / 2, height / 1.975);
+            }
         }
-    }
 
-    Canvas {
-        id: dateCanvas
-
-        property int date: 0
-        property string dateText: ""
-
-        anchors.fill: parent
-        antialiasing: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.beginPath();
-            ctx.fillStyle = Qt.rgba(0, 0, 0, 0.75);
-            ctx.arc(parent.width / 2, parent.height / 2, parent.height * 0.056, 0, 2 * Math.PI, false);
-            ctx.fill();
-            ctx.closePath();
-            ctx.fillStyle = "white";
-            ctx.textAlign = "center";
-            ctx.textBaseline = "middle";
-            ctx.font = "99 " + height / 14 + "px Noto Sans";
-            ctx.fillText(dateText, width / 2, height / 1.975);
-        }
     }
 
     Connections {


### PR DESCRIPTION
## Summary

BRAUN-inspired thick-stroke Canvas face, precursor to several later designs. Conservative pass — all Canvas drawing logic and the dirty-check repaint architecture are preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace legacy block comments with SPDX one-liner format, merge duplicate erroneous 2026 entry into correct 2018 moWerk line, add attribution to analog-precision
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures all Canvas items fill a square region on non-square panels; no changes to drawing logic required

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular face geometry, BRAUN arm rendering, date display, AoD.