### PR TITLE
Refactor analog-words-80s watchface for Qt6

### DIFF
--- a/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
+++ b/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
@@ -11,130 +11,138 @@ Item {
     property string hourColor: ''
     property var neonColor: ["#99FF00E3", "#993500FF", "#9901FE01", "#99FFFE37", "#99FF8600", "#99ED0003", "#9900ffff", "#9938FF12", "#99007FFF", "#99FAAB00"]
     property string imgPath: "../watchfaces-img/analog-words-80s-"
+    property real maxSize: Math.min(width, height)
+
+    anchors.fill: parent
 
     Component.onCompleted: {
         root.currentHour = wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
         root.hourColor = Math.floor(Math.random() * neonColor.length);
     }
+    
+    Item {
+        id: faceBox
 
-    Image {
-        id: backplate
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
-        z: 0
-        source: imgPath + "backplate.svg"
-        opacity: displayAmbient ? 0.3 : 0.5
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
-    }
+        Image {
+            id: backplate
 
-    Image {
-        id: hourOverlay
-
-        z: 1
-        source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + ".svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
-        layer.enabled: true
-
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 0
-            verticalOffset: 0
-            radius: 14
-            samples: 9
-            color: neonColor[hourColor]
+            z: 0
+            source: imgPath + "backplate.svg"
+            opacity: displayAmbient ? 0.3 : 0.5
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
         }
 
-    }
+        Image {
+            id: hourOverlay
 
-    Image {
-        id: hourSVG
+            z: 1
+            source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + ".svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
 
-        z: 0
-        source: imgPath + "hour.svg"
-        anchors.centerIn: root
-        width: root.width
-        height: root.height
-        layer.enabled: true
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: 14
+                samples: 9
+                color: neonColor[hourColor]
+            }
 
-        transform: Rotation {
-            origin.x: hourSVG.width / 2
-            origin.y: hourSVG.height / 2
-            angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
         }
 
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 1
-            verticalOffset: 1
-            radius: 8
-            samples: 9
-            color: neonColor[hourColor]
+        Image {
+            id: hourSVG
+
+            z: 0
+            source: imgPath + "hour.svg"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
+
+            transform: Rotation {
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+                angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+            }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 1
+                verticalOffset: 1
+                radius: 8
+                samples: 9
+                color: neonColor[hourColor]
+            }
+
         }
 
-    }
+        Image {
+            id: minuteSVG
 
-    Image {
-        id: minuteSVG
+            z: 3
+            source: imgPath + "minute.svg"
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
 
-        z: 3
-        source: imgPath + "minute.svg"
-        width: root.width
-        height: root.height
-        layer.enabled: true
+            anchors.centerIn: parent
 
-        anchors {
-            centerIn: root
+            transform: Rotation {
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+            }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 2
+                verticalOffset: 2
+                radius: 8
+                samples: 10
+                color: neonColor[hourColor]
+            }
+
         }
 
-        transform: Rotation {
-            origin.x: minuteSVG.width / 2
-            origin.y: minuteSVG.height / 2
-            angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+        Image {
+            id: secondSVG
+
+            z: 4
+            visible: !displayAmbient
+            source: imgPath + "second.svg"
+            width: parent.width
+            height: parent.width
+            layer.enabled: true
+
+            anchors.centerIn: parent
+
+            transform: Rotation {
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+                angle: (wallClock.time.getSeconds() * 6)
+            }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 6
+                verticalOffset: 6
+                radius: 5
+                samples: 8
+                color: "#66000000"
+            }
+
         }
-
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 2
-            verticalOffset: 2
-            radius: 8
-            samples: 10
-            color: neonColor[hourColor]
-        }
-
-    }
-
-    Image {
-        id: secondSVG
-
-        z: 4
-        visible: !displayAmbient
-        source: imgPath + "second.svg"
-        width: root.width
-        height: root.height
-        layer.enabled: true
-
-        anchors {
-            centerIn: root
-        }
-
-        transform: Rotation {
-            origin.x: secondSVG.width / 2
-            origin.y: secondSVG.height / 2
-            angle: (wallClock.time.getSeconds() * 6)
-        }
-
-        layer.effect: DropShadow {
-            transparentBorder: true
-            horizontalOffset: 6
-            verticalOffset: 6
-            radius: 5
-            samples: 8
-            color: "#66000000"
-        }
-
+        
     }
 
     Connections {

--- a/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
+++ b/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
@@ -14,12 +14,11 @@ Item {
     property real maxSize: Math.min(width, height)
 
     anchors.fill: parent
-
     Component.onCompleted: {
         root.currentHour = wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
         root.hourColor = Math.floor(Math.random() * neonColor.length);
     }
-    
+
     Item {
         id: faceBox
 
@@ -94,7 +93,6 @@ Item {
             width: parent.width
             height: parent.width
             layer.enabled: true
-
             anchors.centerIn: parent
 
             transform: Rotation {
@@ -123,7 +121,6 @@ Item {
             width: parent.width
             height: parent.width
             layer.enabled: true
-
             anchors.centerIn: parent
 
             transform: Rotation {
@@ -132,17 +129,8 @@ Item {
                 angle: (wallClock.time.getSeconds() * 6)
             }
 
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 6
-                verticalOffset: 6
-                radius: 5
-                samples: 8
-                color: "#66000000"
-            }
-
         }
-        
+
     }
 
     Connections {

--- a/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
+++ b/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.9

--- a/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
+++ b/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
@@ -60,8 +60,8 @@ Item {
         layer.enabled: true
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: hourSVG.width / 2
+            origin.y: hourSVG.height / 2
             angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
         }
 
@@ -90,8 +90,8 @@ Item {
         }
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: minuteSVG.width / 2
+            origin.y: minuteSVG.height / 2
             angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
         }
 
@@ -121,8 +121,8 @@ Item {
         }
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: secondSVG.width / 2
+            origin.y: secondSVG.height / 2
             angle: (wallClock.time.getSeconds() * 6)
         }
 

--- a/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
+++ b/analog-words-80s/usr/share/asteroid-launcher/watchfaces/analog-words-80s.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Unique neon word clock with randomised per-hour accent colour shared across word overlay and hand glows. Full polish pass — the colour mechanic and layering scheme are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2021
- **Qt6 import fix** — replace QtGraphicalEffects with Qt5Compat.GraphicalEffects, drop version suffixes
- **Fix Rotation transform origins** — reference item ids instead of root in all three hand transforms
- **Add square geometry guard** — faceBox container prevents stretching on non-square panels; intentional z values preserved to keep the neon word overlay composited above the hour hand
- **Remove layer from 60fps second hand** — plain dark shadow on a 60fps item was paying full FBO cost for no meaningful visual contribution

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): word highlight changes on the hour, neon glow on overlay and hands, random colour selection, AoD.