### PR TITLE
Refactor analog-nihil watchface variants for Qt6

### DIFF
--- a/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
+++ b/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
@@ -7,7 +7,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root

--- a/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
+++ b/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
@@ -1,26 +1,11 @@
-/*
- * Copyright (C) 2024 - github.com/turretkeeper
- *               2022 - Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2024 github.com/turretkeeper
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 

--- a/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
+++ b/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
@@ -13,52 +13,64 @@ Item {
     id: root
 
     property string imgPath: "../watchfaces-img/analog-nihil-dark-"
+    property real maxSize: Math.min(width, height)
 
-    Image {
-        id: hourSVG
+    anchors.fill: parent
 
-        anchors.centerIn: root
-        source: imgPath + "hour.svg"
-        width: root.width
-        height: root.height
+    Item {
+        id: faceBox
 
-        transform: Rotation {
-            origin.x: hourSVG.width / 2
-            origin.y: hourSVG.height / 2
-            angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
+
+        Image {
+            id: hourSVG
+
+            anchors.centerIn: parent
+            source: imgPath + "hour.svg"
+            width: parent.width
+            height: parent.width
+
+            transform: Rotation {
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+                angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+            }
+
         }
 
-    }
+        Image {
+            id: minuteSVG
 
-    Image {
-        id: minuteSVG
+            anchors.centerIn: parent
+            source: imgPath + "minute.svg"
+            width: parent.width
+            height: parent.width
 
-        anchors.centerIn: root
-        source: imgPath + "minute.svg"
-        width: root.width
-        height: root.height
+            transform: Rotation {
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+            }
 
-        transform: Rotation {
-            origin.x: minuteSVG.width / 2
-            origin.y: minuteSVG.height / 2
-            angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
         }
 
-    }
+        Image {
+            id: secondSVG
 
-    Image {
-        id: secondSVG
+            anchors.centerIn: parent
+            source: imgPath + "second.svg"
+            width: parent.width
+            height: parent.width
+            visible: !displayAmbient
 
-        anchors.centerIn: root
-        source: imgPath + "second.svg"
-        width: root.width
-        height: root.height
-        visible: !displayAmbient
+            transform: Rotation {
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+                angle: (wallClock.time.getSeconds() * 6)
+            }
 
-        transform: Rotation {
-            origin.x: secondSVG.width / 2
-            origin.y: secondSVG.height / 2
-            angle: (wallClock.time.getSeconds() * 6)
         }
 
     }

--- a/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
+++ b/analog-nihil-dark/usr/share/asteroid-launcher/watchfaces/analog-nihil-dark.qml
@@ -23,8 +23,8 @@ Item {
         height: root.height
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: hourSVG.width / 2
+            origin.y: hourSVG.height / 2
             angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
         }
 
@@ -39,8 +39,8 @@ Item {
         height: root.height
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: minuteSVG.width / 2
+            origin.y: minuteSVG.height / 2
             angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
         }
 
@@ -56,8 +56,8 @@ Item {
         visible: !displayAmbient
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: secondSVG.width / 2
+            origin.y: secondSVG.height / 2
             angle: (wallClock.time.getSeconds() * 6)
         }
 

--- a/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
+++ b/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
@@ -7,7 +7,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root

--- a/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
+++ b/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
@@ -13,52 +13,64 @@ Item {
     id: root
 
     property string imgPath: "../watchfaces-img/analog-nihil-light-"
+    property real maxSize: Math.min(width, height)
 
-    Image {
-        id: hourSVG
+    anchors.fill: parent
 
-        anchors.centerIn: root
-        source: imgPath + ((displayAmbient) ? "hour-standby.svg" : "hour.svg")
-        width: root.width
-        height: root.height
+    Item {
+        id: faceBox
 
-        transform: Rotation {
-            origin.x: hourSVG.width / 2
-            origin.y: hourSVG.height / 2
-            angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
+
+        Image {
+            id: hourSVG
+
+            anchors.centerIn: parent
+            source: imgPath + ((displayAmbient) ? "hour-standby.svg" : "hour.svg")
+            width: parent.width
+            height: parent.width
+
+            transform: Rotation {
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+                angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+            }
+
         }
 
-    }
+        Image {
+            id: minuteSVG
 
-    Image {
-        id: minuteSVG
+            anchors.centerIn: parent
+            source: imgPath + "minute.svg"
+            width: parent.width
+            height: parent.width
 
-        anchors.centerIn: root
-        source: imgPath + "minute.svg"
-        width: root.width
-        height: root.height
+            transform: Rotation {
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+            }
 
-        transform: Rotation {
-            origin.x: minuteSVG.width / 2
-            origin.y: minuteSVG.height / 2
-            angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
         }
 
-    }
+        Image {
+            id: secondSVG
 
-    Image {
-        id: secondSVG
+            anchors.centerIn: parent
+            source: imgPath + "second.svg"
+            width: parent.width
+            height: parent.width
+            visible: !displayAmbient
 
-        anchors.centerIn: root
-        source: imgPath + "second.svg"
-        width: root.width
-        height: root.height
-        visible: !displayAmbient
+            transform: Rotation {
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+                angle: (wallClock.time.getSeconds() * 6)
+            }
 
-        transform: Rotation {
-            origin.x: secondSVG.width / 2
-            origin.y: secondSVG.height / 2
-            angle: (wallClock.time.getSeconds() * 6)
         }
 
     }

--- a/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
+++ b/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
@@ -1,26 +1,11 @@
-/*
- * Copyright (C) 2024 - github.com/turretkeeper
- *               2022 - Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2024 github.com/turretkeeper
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 

--- a/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
+++ b/analog-nihil-light/usr/share/asteroid-launcher/watchfaces/analog-nihil-light.qml
@@ -23,8 +23,8 @@ Item {
         height: root.height
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: hourSVG.width / 2
+            origin.y: hourSVG.height / 2
             angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
         }
 
@@ -39,8 +39,8 @@ Item {
         height: root.height
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: minuteSVG.width / 2
+            origin.y: minuteSVG.height / 2
             angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
         }
 
@@ -56,8 +56,8 @@ Item {
         visible: !displayAmbient
 
         transform: Rotation {
-            origin.x: root.width / 2
-            origin.y: root.height / 2
+            origin.x: secondSVG.width / 2
+            origin.y: secondSVG.height / 2
             angle: (wallClock.time.getSeconds() * 6)
         }
 


### PR DESCRIPTION
## Summary

Minimal SVG hand face supplied as dark and light colour variants by turretkeeper. Both variants are near-identical and handled together in all commits. Consolidation into a single settings-driven face is planned for a future watchface store cleanup pass.

## Commits

- **Convert SPDX headers** — replace legacy block comments in both variants, correct eLtMosen handle to moWerk
- **Qt6 import fix** — drop QtQuick version suffix in both variants
- **Fix Rotation transform origins** — reference item ids instead of root in all three hand transforms in both variants
- **Add square geometry guard** — faceBox container prevents hand SVG stretching on non-square panels in both variants

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular face geometry, hand rotation, AoD (light variant ambient hand SVG swap verified).