### PR TITLE
Refactor analog-silver-swerver watchface for Qt6

### DIFF
--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -9,10 +9,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 // QtQuick must precede Qt5Compat.GraphicalEffects when LinearGradient is used
 // GraphicalEffects types inherit from QtQuick.Item and require it to be loaded first.
 import QtQuick
-import Qt5Compat.GraphicalEffects
 import QtQuick.Shapes as Shapes
 
 Item {
@@ -532,16 +532,6 @@ Item {
 
         }
 
-    }
-
-    Connections {
-        function onTimeChanged() {
-            if (!visible)
-                return ;
-
-        }
-
-        target: wallClock
     }
 
 }

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -1,28 +1,12 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce 1.0
 import QtGraphicalEffects 1.15

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -26,8 +26,6 @@ Item {
     property real rad: 0.01745
 
     anchors.fill: parent
-    // DropShadow on all hands
-    layer.enabled: true
 
     MceBatteryLevel {
         id: batteryChargePercentage
@@ -528,15 +526,6 @@ Item {
                 angle: (wallClock.time.getSeconds() * 6)
             }
 
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 6
-                verticalOffset: 6
-                radius: 8
-                samples: 9
-                color: Qt.rgba(0, 0, 0, 0.3)
-            }
-
         }
 
     }
@@ -549,15 +538,6 @@ Item {
         }
 
         target: wallClock
-    }
-
-    layer.effect: DropShadow {
-        transparentBorder: true
-        horizontalOffset: 2
-        verticalOffset: 2
-        radius: 8
-        samples: 17
-        color: Qt.rgba(0, 0, 0, 0.3)
     }
 
 }

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -49,13 +49,6 @@ Item {
             anchors.fill: parent
             visible: nightstandMode.active
 
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
-
             Shapes.Shape {
                 id: chargeArc
 

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -472,9 +472,9 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
-                angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
             }
 
             layer.effect: DropShadow {
@@ -496,9 +496,9 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
-                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
+                angle: (wallClock.time.getSeconds() * 6)
             }
 
             layer.effect: DropShadow {

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -8,12 +8,12 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import Nemo.Mce
+// QtQuick must precede Qt5Compat.GraphicalEffects when LinearGradient is used
+// GraphicalEffects types inherit from QtQuick.Item and require it to be loaded first.
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Shapes as Shapes
 
 Item {
     id: root
@@ -56,7 +56,7 @@ Item {
                 textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
             }
 
-            Shape {
+            Shapes.Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
@@ -68,7 +68,7 @@ Item {
 
                 anchors.fill: parent
 
-                ShapePath {
+                Shapes.ShapePath {
                     fillColor: "transparent"
                     strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
                     strokeWidth: parent.height * chargeArc.arcStrokeWidth

--- a/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
+++ b/analog-silver-swerver/usr/share/asteroid-launcher/watchfaces/analog-silver-swerver.qml
@@ -23,6 +23,7 @@ Item {
     property string accColor: !displayAmbient ? "#aeacb9" : "#aaaeacb9"
     property string accColor2: !displayAmbient ? "#F55D3E" : "#88F55D3E"
     property string imgPath: "../watchfaces-img/analog-silver-swerver-"
+    property real maxSize: Math.min(width, height)
     property real rad: 0.01745
 
     anchors.fill: parent
@@ -34,7 +35,9 @@ Item {
     Item {
         id: faceBox
 
-        anchors.fill: parent
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
         // DropShadow on all faceBox items
         layer.enabled: true
 
@@ -62,17 +65,17 @@ Item {
                 Shapes.ShapePath {
                     fillColor: "transparent"
                     strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-                    strokeWidth: parent.height * chargeArc.arcStrokeWidth
+                    strokeWidth: chargeArc.height * chargeArc.arcStrokeWidth
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
-                    startX: width / 2
-                    startY: height * (0.5 - chargeArc.scalefactor)
+                    startX: chargeArc.width / 2
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
-                        centerX: parent.width / 2
-                        centerY: parent.height / 2
-                        radiusX: chargeArc.scalefactor * parent.width
-                        radiusY: chargeArc.scalefactor * parent.height
+                        centerX: chargeArc.width / 2
+                        centerY: chargeArc.height / 2
+                        radiusX: chargeArc.scalefactor * chargeArc.width
+                        radiusY: chargeArc.scalefactor * chargeArc.height
                         startAngle: -90
                         sweepAngle: chargeArc.angle
                         moveToStart: false
@@ -183,7 +186,7 @@ Item {
                 height: width
                 radius: width / 2
                 color: "#22ffffff"
-                border.width: root.height * 0.002
+                border.width: root.maxSize * 0.002
                 border.color: lowColor
                 opacity: !displayAmbient ? 1 : 0.3
             }
@@ -198,7 +201,7 @@ Item {
                     var ctx = getContext("2d");
                     var day = wallClock.time.getDay();
                     ctx.reset();
-                    ctx.lineWidth = root.height * 0.005;
+                    ctx.lineWidth = root.maxSize * 0.005;
                     ctx.lineCap = "round";
                     ctx.strokeStyle = accColor;
                     ctx.beginPath();
@@ -227,7 +230,7 @@ Item {
                     text: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
 
                     font {
-                        pixelSize: currentDayHighlight ? root.height * 0.036 : root.height * 0.03
+                        pixelSize: currentDayHighlight ? root.maxSize * 0.036 : root.maxSize * 0.03
                         letterSpacing: parent.width * 0.004
                         family: "Noto Sans"
                         styleName: currentDayHighlight ? "Black" : "SemiCondensed Bold"
@@ -287,7 +290,7 @@ Item {
                 height: width
                 radius: width / 2
                 color: "#22ffffff"
-                border.width: root.height * 0.002
+                border.width: root.maxSize * 0.002
                 border.color: lowColor
                 opacity: !displayAmbient ? 1 : 0.3
             }
@@ -302,7 +305,7 @@ Item {
                     var ctx = getContext("2d");
                     var m = Number(wallClock.time.toLocaleString(Qt.locale(), "MM"));
                     ctx.reset();
-                    ctx.lineWidth = root.height * 0.005;
+                    ctx.lineWidth = root.maxSize * 0.005;
                     ctx.lineCap = "round";
                     ctx.strokeStyle = accColor;
                     ctx.beginPath();
@@ -330,7 +333,7 @@ Item {
                     text: index === 0 ? 12 : index
 
                     font {
-                        pixelSize: currentMonthHighlight ? root.height * 0.036 : root.height * 0.03
+                        pixelSize: currentMonthHighlight ? root.maxSize * 0.036 : root.maxSize * 0.03
                         letterSpacing: parent.width * 0.004
                         family: "Noto Sans"
                         styleName: currentMonthHighlight ? "Black" : "Condensed Bold"
@@ -393,11 +396,11 @@ Item {
                     ctx.fillStyle = "#22ffffff";
                     ctx.arc(parent.width / 2, parent.height / 2, parent.width * 0.45, 270 * rad, 360, false);
                     ctx.strokeStyle = lowColor;
-                    ctx.lineWidth = root.height * 0.002;
+                    ctx.lineWidth = root.maxSize * 0.002;
                     ctx.stroke();
                     ctx.fill();
                     ctx.closePath();
-                    ctx.lineWidth = root.height * 0.005;
+                    ctx.lineWidth = root.maxSize * 0.005;
                     ctx.lineCap = "round";
                     ctx.strokeStyle = batteryBox.value < 30 ? accColor2 : "#2E933C";
                     ctx.beginPath();
@@ -462,7 +465,9 @@ Item {
     Item {
         id: handBox
 
-        anchors.fill: parent
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
         Image {
             id: hourSVG
@@ -472,9 +477,9 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: minuteSVG.width / 2
-                origin.y: minuteSVG.height / 2
-                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
+                angle: (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
             }
 
             layer.effect: DropShadow {
@@ -496,9 +501,9 @@ Item {
             layer.enabled: true
 
             transform: Rotation {
-                origin.x: secondSVG.width / 2
-                origin.y: secondSVG.height / 2
-                angle: (wallClock.time.getSeconds() * 6)
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
+                angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
             }
 
             layer.effect: DropShadow {
@@ -518,11 +523,10 @@ Item {
             visible: !displayAmbient
             source: imgPath + "second.svg"
             anchors.fill: parent
-            layer.enabled: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
                 angle: (wallClock.time.getSeconds() * 6)
             }
 


### PR DESCRIPTION
## Summary

Goldie sibling in a silver theme with enlarged sub-dials and no bezel. Full polish pass across seven commits covering SPDX, Qt6 imports, nightstand layer fix, layer cleanup, rotation origins, square geometry, and dead code removal.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct eLtMosen handle to moWerk
- **Fix Qt6 imports** — replace QtGraphicalEffects, drop version suffixes, retain Shapes alias for LinearGradient load order, remove unused org.asteroid imports
- **Remove nightstandMode layer block** — layer.enabled on nightstand Item causes GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT on affected hardware
- **Remove unnecessary layer usage** — root layer and secondSVG layer removed; compositing the full scene and a 60fps hand through FBO passes was not justified
- **Fix Rotation transform origins** — reference item ids instead of parent in all three hand transforms
- **Fix square geometry** — faceBox and handBox changed from anchors.fill to explicit square sizing; root.height references in sub-dial text and borders switched to root.maxSize
- **Remove empty Connections block** — wallClock handler contained only an early return; all hands use declarative bindings

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): circular face geometry, sub-dial arcs and text, LinearGradient on numerals, nightstand mode charge arc, AoD.

## Notes

The QtQuick.Shapes as Shapes alias is retained intentionally. It ensures QtQuick loads before Qt5Compat.GraphicalEffects, which is required for LinearGradient to resolve its anchors property correctly. A comment in the import block documents this exception.