### PR TITLE
Refactor analog-square watchface for Qt6

### DIFF
--- a/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
+++ b/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
@@ -4,131 +4,144 @@
 import QtQuick
 
 Item {
+    id: root
+
     property string imgPath: "../watchfaces-img/analog-square-"
-    property real pip: width * 0.43
-    property int nonsquare: height - width
+    property real pip: Math.min(width, height) * 0.43
+    property int nonsquare: 0
 
-    Component {
-        id: minute_pip
+    anchors.fill: parent
 
-        Rectangle {
-            property bool major: index % 5 === 2
-            property int quadrant: index / 15
-            property int rotangle: 48 + 6 * index
-            property real degrees: rotangle + (quadrant & 1 ? 90 : 0)
-            property real radians: degrees * Math.PI / 180
-            property real a: 1 / Math.tan(radians)
-            property real delta: parent.width * 0.02
+    Item {
+        id: faceBox
 
-            color: major ? "lightblue" : "darkgray"
-            radius: width * 0.5
-            width: parent.width * 0.05 + (major ? delta : 0)
-            height: parent.width * 0.01
-            x: parent.width / 2
-            y: (parent.height + height) / 2
-            transform: [
-                Translate {
-                    x: pip * Math.sqrt(1 + a * a) - (major ? delta : 0) + (quadrant & 1 ? 0 : nonsquare / 2)
-                },
-                Rotation {
-                    angle: rotangle
-                }
-            ]
-        }
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
-    }
+        Component {
+            id: minute_pip
 
-    Repeater {
-        model: 60
-        delegate: minute_pip
-    }
+            Rectangle {
+                property bool major: index % 5 === 2
+                property int quadrant: index / 15
+                property int rotangle: 48 + 6 * index
+                property real degrees: rotangle + (quadrant & 1 ? 90 : 0)
+                property real radians: degrees * Math.PI / 180
+                property real a: 1 / Math.tan(radians)
+                property real delta: parent.width * 0.02
 
-    WatchText {
-        id: dayDisplay
-
-        font.pixelSize: parent.height / 24
-        text: Qt.formatDate(wallClock.time, "dddd").toUpperCase()
-
-        anchors {
-            verticalCenter: parent.verticalCenter
-            verticalCenterOffset: -parent.height * 0.23
-        }
-
-    }
-
-    WatchText {
-        id: digitalDisplay
-
-        font.pixelSize: parent.height / 14
-        anchors.top: dayDisplay.bottom
-        text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
-    }
-
-    WatchText {
-        id: dateDisplay
-
-        font.pixelSize: parent.height * 0.1
-        text: Qt.formatDate(wallClock.time, "d")
-
-        anchors {
-            verticalCenter: parent.verticalCenter
-            verticalCenterOffset: parent.height * 0.164
-        }
-
-    }
-
-    WatchText {
-        id: monthDisplay
-
-        font.pixelSize: parent.height * 0.05
-        anchors.top: dateDisplay.bottom
-        text: Qt.formatDate(wallClock.time, "MMMM")
-    }
-
-    Repeater {
-        model: 12
-
-        Item {
-            property real radians: 2 * Math.PI * index / 12
-
-            x: parent.width / 2 + Math.cos(radians) * parent.width * 0.356 - width / 2
-            y: parent.height / 2 + Math.sin(radians) * parent.height * 0.356 - height / 2
-            width: parent.width * 0.1
-            height: parent.height * 0.1
-
-            HourNumberText {
-                id: hourNumbers
-
-                font.pixelSize: parent.height * 0.8
-                text: (index + 2) % 12 + 1
-                anchors.centerIn: parent
-                verticalAlignment: Text.AlignVCenter
+                color: major ? "lightblue" : "darkgray"
+                radius: width * 0.5
+                width: parent.width * 0.05 + (major ? delta : 0)
+                height: parent.width * 0.01
+                x: parent.width / 2
+                y: (parent.height + height) / 2
+                transform: [
+                    Translate {
+                        x: pip * Math.sqrt(1 + a * a) - (major ? delta : 0) + (quadrant & 1 ? 0 : nonsquare / 2)
+                    },
+                    Rotation {
+                        angle: rotangle
+                    }
+                ]
             }
 
         }
 
-    }
+        Repeater {
+            model: 60
+            delegate: minute_pip
+        }
 
-    WatchHand {
-        id: hourSVG
+        WatchText {
+            id: dayDisplay
 
-        source: imgPath + "hour.svg"
-        rotationAngle: (wallClock.time.getHours() + wallClock.time.getMinutes() / 60) * 360 / 12
-    }
+            font.pixelSize: parent.height / 24
+            text: Qt.formatDate(wallClock.time, "dddd").toUpperCase()
 
-    WatchHand {
-        id: minuteSVG
+            anchors {
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * 0.23
+            }
 
-        source: imgPath + "minute.svg"
-        rotationAngle: (wallClock.time.getMinutes() + wallClock.time.getSeconds() / 60) * 360 / 60
-    }
+        }
 
-    WatchHand {
-        id: secondSVG
+        WatchText {
+            id: digitalDisplay
 
-        visible: !displayAmbient
-        source: imgPath + "second.svg"
-        rotationAngle: wallClock.time.getSeconds() * 360 / 60
+            font.pixelSize: parent.height / 14
+            anchors.top: dayDisplay.bottom
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
+        }
+
+        WatchText {
+            id: dateDisplay
+
+            font.pixelSize: parent.height * 0.1
+            text: Qt.formatDate(wallClock.time, "d")
+
+            anchors {
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: parent.height * 0.164
+            }
+
+        }
+
+        WatchText {
+            id: monthDisplay
+
+            font.pixelSize: parent.height * 0.05
+            anchors.top: dateDisplay.bottom
+            text: Qt.formatDate(wallClock.time, "MMMM")
+        }
+
+        Repeater {
+            model: 12
+
+            Item {
+                property real radians: 2 * Math.PI * index / 12
+
+                x: parent.width / 2 + Math.cos(radians) * parent.width * 0.356 - width / 2
+                y: parent.height / 2 + Math.sin(radians) * parent.height * 0.356 - height / 2
+                width: parent.width * 0.1
+                height: parent.height * 0.1
+
+                HourNumberText {
+                    id: hourNumbers
+
+                    font.pixelSize: parent.height * 0.8
+                    text: (index + 2) % 12 + 1
+                    anchors.centerIn: parent
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+            }
+
+        }
+
+        WatchHand {
+            id: hourSVG
+
+            source: imgPath + "hour.svg"
+            rotationAngle: (wallClock.time.getHours() + wallClock.time.getMinutes() / 60) * 360 / 12
+        }
+
+        WatchHand {
+            id: minuteSVG
+
+            source: imgPath + "minute.svg"
+            rotationAngle: (wallClock.time.getMinutes() + wallClock.time.getSeconds() / 60) * 360 / 60
+        }
+
+        WatchHand {
+            id: secondSVG
+
+            visible: !displayAmbient
+            source: imgPath + "second.svg"
+            rotationAngle: wallClock.time.getSeconds() * 360 / 60
+        }
+
     }
 
     component WatchText: Text {

--- a/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
+++ b/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Ed Beroset <github.com/beroset>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     property string imgPath: "../watchfaces-img/analog-square-"

--- a/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
+++ b/analog-square/usr/share/asteroid-launcher/watchfaces/analog-square.qml
@@ -1,21 +1,5 @@
-/*
-* Copyright (C) 2025 - Ed Beroset <github.com/beroset>
-*
-* All rights reserved.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Lesser General Public License as
-* published by the Free Software Foundation, either version 2.1 of the
-* License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+// SPDX-FileCopyrightText: 2025 Ed Beroset <github.com/beroset>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 


### PR DESCRIPTION
## Summary

Recent face by beroset using Qt6-only inline component definitions. Minimal Qt6 changes plus a square geometry guard added for consistency with the rest of the collection.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container constrains the face to a square on non-square panels; nonsquare property set to 0 since the offset is no longer needed

## Testing

Tested on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): face renders as centred square, tick mark positions, hour numerals, hand rotation, AoD.

## Notes

The original nonsquare property suggested possible intent to fill non-square panels. This PR constrains it to a square for consistency. Please confirm your preference in review. The nonsquare tick offset mechanism can be restored by reverting the last commit if the rectangular layout was intentional.