### PR TITLE
Refactor analog-sundial watchface for Qt6

### DIFF
--- a/analog-sundial/usr/share/asteroid-launcher/watchfaces/analog-sundial.qml
+++ b/analog-sundial/usr/share/asteroid-launcher/watchfaces/analog-sundial.qml
@@ -7,7 +7,7 @@
 // Ambient: shadow hidden; time and date remain.
 // Font: JetBrains Mono (OFL)
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root

--- a/analog-sundial/usr/share/asteroid-launcher/watchfaces/analog-sundial.qml
+++ b/analog-sundial/usr/share/asteroid-launcher/watchfaces/analog-sundial.qml
@@ -1,14 +1,11 @@
-/*
- * Horizon line across the center; big JetBrains Mono HH:MM sits above it.
- * A gnomon shadow arm sweeps with the seconds, tinted by time of day
- * (amber at noon, indigo at midnight). Date below the horizon.
- *
- * Ambient: shadow hidden; time and date remain.
- *
- * Font: JetBrains Mono (OFL)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+// Sundial — AsteroidOS watchface
+// Horizon line across the center; big JetBrains Mono HH:MM sits above it.
+// A gnomon shadow arm sweeps with the seconds, tinted by time of day
+// (amber at noon, indigo at midnight). Date below the horizon.
+// Ambient: shadow hidden; time and date remain.
+// Font: JetBrains Mono (OFL)
 
 import QtQuick 2.15
 


### PR DESCRIPTION
## Summary

Recently written face, minimal changes needed.

## Commits

- **Move design comment below SPDX header** — convert block comment to // line format
- **Qt6 import fix** — drop QtQuick version suffix

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): smooth shadow sweep, time-of-day tint, date text, AoD.