### PR TITLE
Refactor analog-weather-glow watchface for Qt6

### DIFF
--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -96,13 +96,6 @@ Item {
         anchors.fill: parent
         visible: dockMode.active
 
-        layer {
-            enabled: true
-            samples: 4
-            smooth: true
-            textureSize: Qt.size(dockMode.width * 2, dockMode.height * 2)
-        }
-
         Shape {
             id: chargeArc
 

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -998,8 +998,8 @@ Item {
             smooth: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: hourSVG.width / 2
+                origin.y: hourSVG.height / 2
                 angle: hourSVG.toggle24h ? (wallClock.time.getHours() * 15) + (wallClock.time.getMinutes() * 0.25) : (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * 0.5)
             }
 
@@ -1016,8 +1016,8 @@ Item {
             smooth: true
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: minuteSVG.width / 2
+                origin.y: minuteSVG.height / 2
                 angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
             }
 
@@ -1035,8 +1035,8 @@ Item {
             visible: !displayAmbient && !dockMode.active
 
             transform: Rotation {
-                origin.x: parent.width / 2
-                origin.y: parent.height / 2
+                origin.x: secondSVG.width / 2
+                origin.y: secondSVG.height / 2
                 angle: wallClock.time.getSeconds() * 6
             }
 

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -22,7 +22,6 @@ import org.asteroid.utils
 import "weathericons.js" as WeatherIcons
 
 Item {
-    // Uranian Blue
     // Prepare for feature where the secondary hardware button activates HRM mode.
     // Keycode 134 = Sawfish lower button.
     /*Keys.onPressed: {
@@ -60,6 +59,7 @@ Item {
     property string boxColor: "#E8DCB9"
     // Dutch White
     property string switchColor: "#A2D6F9"
+    // Uranian Blue
     // HRM initialisation. Needs to be declared global since hrmBox and hrmSwitch both need it.
     property int hrmBpm: 0
     property bool hrmSensorActive: false
@@ -76,8 +76,6 @@ Item {
     }
 
     anchors.fill: parent
-    // Slight dropshadow under all Items.
-    layer.enabled: true
 
     MceBatteryState {
         id: batteryChargeState
@@ -1063,15 +1061,6 @@ Item {
         }
 
         target: compositor
-    }
-
-    layer.effect: DropShadow {
-        transparentBorder: true
-        horizontalOffset: 1
-        verticalOffset: 1
-        radius: 6
-        samples: 9
-        color: Qt.rgba(0, 0, 0, 0.7)
     }
 
 }

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -11,10 +11,10 @@
 import Connman
 import Nemo.Configuration
 import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 // QtQuick must precede Qt5Compat.GraphicalEffects when ColorOverlay is used —
 // GraphicalEffects types inherit from QtQuick.Item and require it to be loaded first.
 import QtQuick
-import Qt5Compat.GraphicalEffects
 import QtQuick.Shapes
 import QtSensors
 import org.asteroid.controls
@@ -96,17 +96,17 @@ Item {
         visible: dockMode.active
 
         Shape {
-                id: chargeArc
+            id: chargeArc
 
-                property real angle: batteryChargePercentage.percent * 360 / 100
-                property real arcStrokeWidth: 0.016
-                property real scalefactor: 0.39 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
+            property real angle: batteryChargePercentage.percent * 360 / 100
+            property real arcStrokeWidth: 0.016
+            property real scalefactor: 0.39 - (arcStrokeWidth / 2)
+            property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+            readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
-                width: root.maxSize
-                height: root.maxSize
-                anchors.centerIn: parent
+            width: root.maxSize
+            height: root.maxSize
+            anchors.centerIn: parent
 
             ShapePath {
                 fillColor: "transparent"
@@ -1046,16 +1046,6 @@ Item {
 
         }
 
-    }
-
-    Connections {
-        function onTimeChanged() {
-            if (!visible)
-                return ;
-
-        }
-
-        target: wallClock
     }
 
     Connections {

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -37,12 +37,13 @@ Item {
     // Radian per degree used by all canvas arcs
     property real rad: 0.01745
     // Element sizes, positioning, linewidth and opacity
-    property real switchSize: root.width * 0.1375
-    property real boxSize: root.width * 0.35
-    property real switchPosition: root.width * 0.26
-    property real boxPosition: root.width * 0.25
-    property real innerArcLineWidth: root.height * 0.008
-    property real outerArcLineWidth: root.height * 0.016
+    property real maxSize: Math.min(width, height)
+    property real switchSize: maxSize * 0.1375
+    property real boxSize: maxSize * 0.35
+    property real switchPosition: maxSize * 0.26
+    property real boxPosition: maxSize * 0.25
+    property real innerArcLineWidth: maxSize * 0.008
+    property real outerArcLineWidth: maxSize * 0.016
     property real activeArcOpacity: !displayAmbient ? 0.7 : 0.4
     property real inactiveArcOpacity: !displayAmbient ? 0.5 : 0.3
     property real activeContentOpacity: !displayAmbient ? 0.95 : 0.6
@@ -95,15 +96,17 @@ Item {
         visible: dockMode.active
 
         Shape {
-            id: chargeArc
+                id: chargeArc
 
-            property real angle: batteryChargePercentage.percent * 360 / 100
-            property real arcStrokeWidth: 0.016
-            property real scalefactor: 0.39 - (arcStrokeWidth / 2)
-            property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-            readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
+                property real angle: batteryChargePercentage.percent * 360 / 100
+                property real arcStrokeWidth: 0.016
+                property real scalefactor: 0.39 - (arcStrokeWidth / 2)
+                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
-            anchors.fill: parent
+                width: root.maxSize
+                height: root.maxSize
+                anchors.centerIn: parent
 
             ShapePath {
                 fillColor: "transparent"
@@ -199,7 +202,7 @@ Item {
             text: (index === 0 ? 12 : index) * (hourSVG.toggle24h ? 2 : 1)
 
             font {
-                pixelSize: root.height * 0.06
+                pixelSize: root.maxSize * 0.06
                 family: "Noto Sans"
                 styleName: "Bold"
             }
@@ -982,8 +985,9 @@ Item {
         // Wrapper for the analog hands
         id: handBox
 
-        width: root.width
-        height: root.height
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
         Image {
             id: hourSVG

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -98,7 +98,6 @@ Item {
             id: chargeArc
 
             property real angle: batteryChargePercentage.percent * 360 / 100
-            // radius of arc is scalefactor * height or width
             property real arcStrokeWidth: 0.016
             property real scalefactor: 0.39 - (arcStrokeWidth / 2)
             property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
@@ -109,17 +108,17 @@ Item {
             ShapePath {
                 fillColor: "transparent"
                 strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-                strokeWidth: parent.height * chargeArc.arcStrokeWidth
+                strokeWidth: chargeArc.height * chargeArc.arcStrokeWidth
                 capStyle: ShapePath.RoundCap
                 joinStyle: ShapePath.MiterJoin
-                startX: width / 2
-                startY: height * (0.5 - chargeArc.scalefactor)
+                startX: chargeArc.width / 2
+                startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                 PathAngleArc {
-                    centerX: parent.width / 2
-                    centerY: parent.height / 2
-                    radiusX: chargeArc.scalefactor * parent.width
-                    radiusY: chargeArc.scalefactor * parent.height
+                    centerX: chargeArc.width / 2
+                    centerY: chargeArc.height / 2
+                    radiusX: chargeArc.scalefactor * chargeArc.width
+                    radiusY: chargeArc.scalefactor * chargeArc.height
                     startAngle: -90
                     sweepAngle: chargeArc.angle
                     moveToStart: false

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -1,27 +1,12 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Connman 0.2
 import Nemo.Configuration 1.0

--- a/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
+++ b/analog-weather-glow/usr/share/asteroid-launcher/watchfaces/analog-weather-glow.qml
@@ -8,15 +8,17 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Connman 0.2
-import Nemo.Configuration 1.0
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
-import QtSensors 5.11
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import Connman
+import Nemo.Configuration
+import Nemo.Mce
+// QtQuick must precede Qt5Compat.GraphicalEffects when ColorOverlay is used —
+// GraphicalEffects types inherit from QtQuick.Item and require it to be loaded first.
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Shapes
+import QtSensors
+import org.asteroid.controls
+import org.asteroid.utils
 import "weathericons.js" as WeatherIcons
 
 Item {


### PR DESCRIPTION
## Summary

The most complex face in the collection — weather data, HRM sensor, bluetooth and wifi toggles, dock mode charge arc, and 12/24h toggle. Full polish pass across eight commits. All interactive features and sensor integrations preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2022, correct moWerk handle
- **Fix Qt6 imports** — replace QtGraphicalEffects, drop all version suffixes; QtQuick listed before Qt5Compat.GraphicalEffects for ColorOverlay load order
- **Remove dockMode layer block** — layer.enabled on nightstand item causes GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT on affected hardware
- **Remove root layer** — full-scene FBO compositing for a subtle edge shadow not justified
- **Fix chargeArc PathAngleArc** — replace parent references with chargeArc id in ShapePath and PathAngleArc to ensure correct dimension resolution
- **Fix Rotation transform origins** — reference item ids instead of parent in all three hand transforms
- **Fix square geometry** — maxSize property introduced; all sizing and positioning properties derived from maxSize; handBox given explicit square dimensions
- **Remove empty Connections block** — wallClock handler was dead code; all hands use declarative bindings

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px), compared against 1.1 nightly Qt 5.15 (tunny 400px). Verified on beluga 41mm (320x360px): all box positions, arc geometry, weather data display, HRM toggle, bluetooth and wifi toggles, 12/24h toggle, dock mode charge arc, AoD.