### PR TITLE
Refactor analog-zeitgeber watchface for Qt6

### DIFF
--- a/analog-zeitgeber/usr/share/asteroid-launcher/watchfaces/analog-zeitgeber.qml
+++ b/analog-zeitgeber/usr/share/asteroid-launcher/watchfaces/analog-zeitgeber.qml
@@ -1,17 +1,12 @@
-/*
- * Zeitgeber — AsteroidOS watchface
- *
- * 60 ticks around the rim. A golden comet sweeps continuously to the current
- * fractional-minute position via a 16 ms timer. Non-glow ticks render as
- * 5-minute major / minor pairs. Seconds pulse a faint outer ring.
- * A giant hour digit in Major Mono Display sits centred behind.
- *
- * Ambient: current-minute tick + quarter marks + hour digit only.
- *
- * Fonts: Major Mono Display (OFL), Space Mono (OFL)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+// Zeitgeber — AsteroidOS watchface
+// 60 ticks around the rim. A golden comet sweeps continuously to the current
+// fractional-minute position via a 16 ms timer. Non-glow ticks render as
+// 5-minute major / minor pairs. Seconds pulse a faint outer ring.
+// A giant hour digit in Major Mono Display sits centred behind.
+// Ambient: current-minute tick + quarter marks + hour digit only.
+// Fonts: Major Mono Display (OFL), Space Mono (OFL)
 
 import QtQuick 2.15
 

--- a/analog-zeitgeber/usr/share/asteroid-launcher/watchfaces/analog-zeitgeber.qml
+++ b/analog-zeitgeber/usr/share/asteroid-launcher/watchfaces/analog-zeitgeber.qml
@@ -8,7 +8,7 @@
 // Ambient: current-minute tick + quarter marks + hour digit only.
 // Fonts: Major Mono Display (OFL), Space Mono (OFL)
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Recently written face with golden comet sweep and French Revolutionary decimal time. Minimal changes needed.

## Commits

- **Move design comment below SPDX header** — convert block comment to // line format
- **Qt6 import fix** — drop QtQuick version suffix

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): comet sweep, seconds pulse ring, hour digit, decimal time, AoD.