### PR TITLE
Refactor binary-digital watchface for Qt6

### DIFF
--- a/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
+++ b/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
@@ -9,7 +9,7 @@
 // Binary hour and minute bars rotated 90° with digital overlay.
 // Seconds stripped and displays enlarged for cleaner design.
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     id: root

--- a/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
+++ b/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
@@ -16,8 +16,9 @@ Item {
 
     property int radius: Math.min(root.width / 24, root.height / 16)
 
-    width: parent.width
+    width: Math.min(parent.width, parent.height)
     height: width
+    anchors.centerIn: parent
 
     Component {
         id: draw_led_hour
@@ -131,7 +132,7 @@ Item {
 
             anchors {
                 centerIn: parent
-                verticalCenterOffset: parent.height * 0.038
+                verticalCenterOffset: parent.height * 0.12
                 horizontalCenterOffset: -parent.height * 0.235 + hoffset
             }
 
@@ -151,7 +152,7 @@ Item {
 
             anchors {
                 centerIn: parent
-                verticalCenterOffset: parent.height * 0.038
+                verticalCenterOffset: parent.height * 0.12
                 horizontalCenterOffset: parent.height * 0.235 + hoffset
             }
 

--- a/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
+++ b/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-/* Based on binary-lcd watchface but stripped off the seconds and enlarged
- * the binary hour and minute displays for cleaner design and less noise.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// binary-digital — based on binary-lcd watchface
+// Binary hour and minute bars rotated 90° with digital overlay.
+// Seconds stripped and displays enlarged for cleaner design.
 
 import QtQuick 2.1
 

--- a/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
+++ b/binary-digital/usr/share/asteroid-launcher/watchfaces/binary-digital.qml
@@ -160,14 +160,4 @@ Item {
 
     }
 
-    Connections {
-        function onTimeChanged() {
-            if (!visible)
-                return ;
-
-        }
-
-        target: wallClock
-    }
-
 }


### PR DESCRIPTION
## Summary

Binary LED bar face with 90° rotated hour and minute displays and digital overlay. Minimal changes — the bit-shift display mechanic and rotation transforms are preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace legacy block comments, correct erroneous 2026 year to 2018
- **Qt6 import fix** — drop QtQuick version suffix
- **Fix centering on non-square screens** — root Item now uses Math.min and anchors.centerIn rather than sitting at the panel top-left on beluga
- **Remove empty Connections block** — all displays use declarative bindings

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): binary bars centred correctly, digital overlay aligned, AoD.