### PR TITLE
Refactor bold-hour-bebas-v2 watchface for Qt6

### DIFF
--- a/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
+++ b/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 

--- a/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
+++ b/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     id: root

--- a/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
+++ b/bold-hour-bebas-v2/usr/share/asteroid-launcher/watchfaces/bold-hour-bebas-v2.qml
@@ -11,22 +11,31 @@ import QtQuick
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
+
     function updateMinute() {
         var m = wallClock.time.getMinutes();
         var angle = (m - 15) / 60 * 2 * Math.PI;
-        var cx = parent.width / 2;
-        var cy = parent.height / 2;
-        var r = parent.width / 2.75;
+        var cx = root.maxSize / 2;
+        var cy = root.maxSize / 2;
+        var r = root.maxSize / 2.75;
         minuteCircle.minuteX = cx + Math.cos(angle) * r;
         minuteCircle.minuteY = cy + Math.sin(angle) * r;
-        minuteDisplay.x = cx - minuteDisplay.width / 2 + Math.cos(angle) * parent.width * 0.364;
-        minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(angle) * parent.width * 0.364;
+        minuteDisplay.x = cx - minuteDisplay.width / 2 + Math.cos(angle) * root.maxSize * 0.364;
+        minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(angle) * root.maxSize * 0.364;
     }
 
-    Component.onCompleted: {
-        minuteArc.minute = wallClock.time.getMinutes();
-        minuteArc.requestPaint();
-        updateMinute();
+    anchors.fill: parent
+
+    Timer {
+        interval: 1
+        repeat: false
+        running: true
+        onTriggered: {
+            minuteArc.minute = wallClock.time.getMinutes();
+            minuteArc.requestPaint();
+            updateMinute();
+        }
     }
 
     Canvas {
@@ -56,19 +65,23 @@ Item {
     Text {
         id: hourDisplay
 
-        property real offset: height * 0.38
+        property real offset: height * 0.42
 
         renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.94
-        font.family: "Bebas Neue"
-        font.styleName: "Bold"
         color: Qt.rgba(1, 1, 1, 0.85)
         style: Text.Outline
         styleColor: Qt.rgba(0, 0, 0, 0.4)
         horizontalAlignment: Text.AlignHCenter
-        x: parent.width / 2 - width / 1.88
-        y: parent.height / 2 - offset
+        x: root.maxSize / 2 - width / 1.88
+        y: root.maxSize / 2 - offset
         text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+
+        font {
+            pixelSize: root.maxSize * 0.94
+            family: "Bebas Neue"
+            styleName: "Bold"
+        }
+
     }
 
     // Minute circle — plain Rectangle replaces Canvas full-circle arc
@@ -89,11 +102,15 @@ Item {
     Text {
         id: minuteDisplay
 
-        font.pixelSize: parent.height / 5.6
-        font.family: "BebasKai"
-        font.styleName: "Condensed"
         color: "white"
         text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+        font {
+            pixelSize: root.maxSize / 5.6
+            family: "BebasKai"
+            styleName: "Condensed"
+        }
+
     }
 
     Connections {


### PR DESCRIPTION
## Summary

Green-accent variant of the stock bold-hour face with conical gradient minute arc. The Canvas drawing logic and dirty-check repaint architecture are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate erroneous 2026 entry into correct 2018 moWerk line
- **Qt6 import fix** — drop QtQuick version suffix
- **Fix square geometry** — maxSize property, anchors.fill on root, Component.onCompleted replaced with one-shot Timer, orbit math and font sizes switched to root.maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): minute arc geometry, minute circle and text on correct orbit, giant hour digit scaled correctly, AoD.