### PR TITLE
Refactor day-clock-24h watchface for Qt6

### DIFF
--- a/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
+++ b/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
@@ -28,7 +28,6 @@ Item {
         property real hour: 0
         property real minute: 0
 
-        z: 1
         anchors.fill: parent
         renderStrategy: Canvas.Cooperative
         onPaint: {
@@ -48,7 +47,6 @@ Item {
     Image {
         id: backGround
 
-        z: 2
         source: "../watchfaces-img/day-clock-center.svg"
         anchors.centerIn: parent
         width: parent.width / 3
@@ -57,7 +55,6 @@ Item {
         Image {
             id: backStars
 
-            z: 2
             source: "../watchfaces-img/day-clock-center-stars.svg"
             anchors.centerIn: parent
             width: parent.width
@@ -82,7 +79,6 @@ Item {
 
         property real offset: height * 0.5
 
-        z: 3
         color: "white"
         style: Text.Outline
         styleColor: "#80000000"
@@ -105,7 +101,6 @@ Item {
 
         property real offset: height * 0.5
 
-        z: 3
         color: "white"
         style: Text.Outline
         styleColor: "#80000000"
@@ -128,7 +123,6 @@ Item {
 
         property real offset: height * 0.5
 
-        z: 4
         color: "white"
         style: Text.Outline
         styleColor: "#80000000"
@@ -149,7 +143,6 @@ Item {
 
         property real offset: height * 0.5
 
-        z: 4
         color: "white"
         style: Text.Outline
         styleColor: "#80000000"
@@ -169,7 +162,6 @@ Item {
     Text {
         id: dayofweekDisplay
 
-        z: 5
         lineHeight: parent.height * 0.0025
         color: "white"
         style: Text.Outline
@@ -191,7 +183,6 @@ Item {
     Text {
         id: dateDisplay
 
-        z: 6
         lineHeight: parent.height * 0.0025
         color: "white"
         style: Text.Outline

--- a/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
+++ b/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
@@ -13,6 +13,7 @@ import QtQuick
 Item {
     id: root
 
+    anchors.fill: parent
     Component.onCompleted: {
         var h = wallClock.time.getHours();
         var min = wallClock.time.getMinutes();
@@ -44,159 +45,168 @@ Item {
         }
     }
 
-    Image {
-        id: backGround
+    Item {
+        id: faceBox
 
-        source: "../watchfaces-img/day-clock-center.svg"
+        width: Math.min(parent.width, parent.height)
+        height: width
         anchors.centerIn: parent
-        width: parent.width / 3
-        height: parent.height / 3
 
         Image {
-            id: backStars
+            id: backGround
 
-            source: "../watchfaces-img/day-clock-center-stars.svg"
+            source: "../watchfaces-img/day-clock-center.svg"
             anchors.centerIn: parent
-            width: parent.width
-            height: parent.height
-            layer.enabled: true
+            width: parent.width / 3
+            height: parent.height / 3
 
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 0
-                verticalOffset: 0
-                radius: 12
-                samples: 9
-                color: "#ccffcc00"
+            Image {
+                id: backStars
+
+                source: "../watchfaces-img/day-clock-center-stars.svg"
+                anchors.centerIn: parent
+                width: parent.width
+                height: parent.height
+                layer.enabled: true
+
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 0
+                    verticalOffset: 0
+                    radius: 12
+                    samples: 9
+                    color: "#ccffcc00"
+                }
+
             }
 
         }
 
-    }
+        Text {
+            id: hourDisplay
 
-    Text {
-        id: hourDisplay
+            property real offset: height * 0.5
 
-        property real offset: height * 0.5
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.9
+            horizontalAlignment: Text.AlignHCenter
+            x: parent.width / 14
+            y: parent.height / 2.5 - offset
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
 
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.9
-        horizontalAlignment: Text.AlignHCenter
-        x: parent.width / 14
-        y: parent.height / 2.5 - offset
-        text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+            font {
+                pixelSize: parent.height * 0.22
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.22
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
-    }
+        Text {
+            id: minuteDisplay
 
-    Text {
-        id: minuteDisplay
+            property real offset: height * 0.5
 
-        property real offset: height * 0.5
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.9
+            horizontalAlignment: Text.AlignHCenter
+            x: parent.width / 14
+            y: parent.height / 1.65 - offset
+            text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.9
-        horizontalAlignment: Text.AlignHCenter
-        x: parent.width / 14
-        y: parent.height / 1.65 - offset
-        text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+            font {
+                pixelSize: parent.height * 0.22
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.22
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
-    }
+        Text {
+            id: dayDisplay
 
-    Text {
-        id: dayDisplay
+            property real offset: height * 0.5
 
-        property real offset: height * 0.5
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.5
+            x: parent.width * 0.7
+            y: parent.height / 2.5 - offset
 
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.5
-        x: parent.width * 0.7
-        y: parent.height / 2.5 - offset
+            font {
+                pixelSize: parent.height * 0.2
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.2
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
-    }
+        Text {
+            id: percentDisplay
 
-    Text {
-        id: percentDisplay
+            property real offset: height * 0.5
 
-        property real offset: height * 0.5
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.5
+            x: parent.width * 0.73
+            y: parent.height / 1.58 - offset
+            text: "%"
 
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.5
-        x: parent.width * 0.73
-        y: parent.height / 1.58 - offset
-        text: "%"
+            font {
+                pixelSize: parent.height * 0.2
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.2
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
-    }
+        Text {
+            id: dayofweekDisplay
 
-    Text {
-        id: dayofweekDisplay
+            lineHeight: parent.height * 0.0025
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.7
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 9
+            text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
 
-        lineHeight: parent.height * 0.0025
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.7
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 9
-        text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
+            font {
+                pixelSize: parent.height * 0.1
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.1
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
-    }
+        Text {
+            id: dateDisplay
 
-    Text {
-        id: dateDisplay
+            lineHeight: parent.height * 0.0025
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.8
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 1.32
+            text: wallClock.time.toLocaleString(Qt.locale(), "yyyy MM dd")
 
-        lineHeight: parent.height * 0.0025
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.8
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 1.32
-        text: wallClock.time.toLocaleString(Qt.locale(), "yyyy MM dd")
+            font {
+                pixelSize: parent.height * 0.1
+                family: "Vollkorn"
+                styleName: "Regular"
+            }
 
-        font {
-            pixelSize: parent.height * 0.1
-            family: "Vollkorn"
-            styleName: "Regular"
         }
 
     }

--- a/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
+++ b/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
@@ -7,8 +7,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Based on kitt by velox/jgibbon regarding arcs and image embedding.
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root

--- a/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
+++ b/day-clock-24h/usr/share/asteroid-launcher/watchfaces/day-clock-24h.qml
@@ -1,29 +1,11 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-/*
- * Based on kitt by velox/jgibbon regarding arcs and image embedding.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Based on kitt by velox/jgibbon regarding arcs and image embedding.
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.9


### PR DESCRIPTION
## Summary

24-hour day arc with day percentage display and star imagery. The Canvas arc logic and day percentage math are preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace legacy block comments, merge duplicate erroneous 2026 entry into correct 2018 moWerk line, convert attribution to // format
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes
- **Remove redundant z values** — nine z properties removed, declaration order establishes the correct render stack
- **Add square geometry guard** — faceBox container ensures all text positions and arc geometry resolve against a square dimension on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): arc geometry, text positions, star glow, day percentage calculation, AoD.