### PR TITLE
Refactor digital-alternative-default-mosen watchface for Qt6

### DIFF
--- a/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
+++ b/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
@@ -29,8 +29,7 @@ Item {
         ctx.shadowBlur = faceBox.height * 0.0156;
     }
 
-anchors.fill: parent
-
+    anchors.fill: parent
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         var minute = wallClock.time.getMinutes();
@@ -76,7 +75,7 @@ anchors.fill: parent
             onPaint: {
                 var ctx = getContext("2d");
                 prepareContext(ctx);
-                ctx.font = "64 " + height * 0.385 + "px Roboto";
+                ctx.font = "bold " + height * 0.385 + "px Roboto";
                 ctx.fillText(twoDigits(hour), width * 0.3, height * 0.54);
             }
         }
@@ -94,7 +93,7 @@ anchors.fill: parent
                 var ctx = getContext("2d");
                 prepareContext(ctx);
                 ctx.shadowBlur = parent.height * 0.00937; //3 px on 320x320
-                ctx.font = "24 " + height * 0.222 + "px Roboto";
+                ctx.font = "300 " + height * 0.222 + "px Roboto";
                 ctx.fillText(twoDigits(minute), width * 0.642, height * 0.47);
             }
         }
@@ -114,7 +113,7 @@ anchors.fill: parent
                 ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
                 ctx.textAlign = "right";
                 ctx.textBaseline = "right";
-                ctx.font = "22 " + height * 0.111 + "px Roboto";
+                ctx.font = "300 " + height * 0.111 + "px Roboto";
                 ctx.fillText(twoDigits(second), width * 0.902, height * 0.419);
             }
         }
@@ -135,7 +134,7 @@ anchors.fill: parent
                 ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
                 ctx.textAlign = "right";
                 ctx.textBaseline = "right";
-                ctx.font = "14 " + height * 0.08 + "px Raleway";
+                ctx.font = "300 " + height * 0.08 + "px Raleway";
                 ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "AP").slice(0, 2), width * 0.902, height * 0.5135);
             }
         }
@@ -156,7 +155,7 @@ anchors.fill: parent
                 ctx.textAlign = "center";
                 ctx.textBaseline = "middle";
                 var ctx = getContext("2d");
-                ctx.font = "20 " + height * 0.111 + "px Raleway";
+                ctx.font = "300 " + height * 0.111 + "px Raleway";
                 ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase(), width * 0.642, height * 0.615);
             }
         }
@@ -177,7 +176,7 @@ anchors.fill: parent
                 ctx.textAlign = "right";
                 ctx.textBaseline = "right";
                 var ctx = getContext("2d");
-                ctx.font = "42 " + height * 0.112 + "px Roboto";
+                ctx.font = "500 " + height * 0.112 + "px Roboto";
                 ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "dd"), width * 0.902, height * 0.612);
             }
         }

--- a/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
+++ b/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
@@ -9,6 +9,8 @@
 import QtQuick
 
 Item {
+    id: root
+
     function twoDigits(x) {
         if (x < 10)
             return "0" + x;
@@ -22,10 +24,12 @@ Item {
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.shadowColor = Qt.rgba(0, 0, 0, 0.8);
-        ctx.shadowOffsetX = parent.height * 0.00625;
-        ctx.shadowOffsetY = parent.height * 0.00625;
-        ctx.shadowBlur = parent.height * 0.0156;
+        ctx.shadowOffsetX = faceBox.height * 0.00625;
+        ctx.shadowOffsetY = faceBox.height * 0.00625;
+        ctx.shadowBlur = faceBox.height * 0.0156;
     }
+
+anchors.fill: parent
 
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
@@ -53,122 +57,131 @@ Item {
         amPmCanvas.requestPaint();
     }
 
-    Canvas {
-        id: hourCanvas
+    Item {
+        id: faceBox
 
-        property real hour: 0
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.font = "64 " + height * 0.385 + "px Roboto";
-            ctx.fillText(twoDigits(hour), width * 0.3, height * 0.54);
+        Canvas {
+            id: hourCanvas
+
+            property real hour: 0
+
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.font = "64 " + height * 0.385 + "px Roboto";
+                ctx.fillText(twoDigits(hour), width * 0.3, height * 0.54);
+            }
         }
-    }
 
-    Canvas {
-        id: minuteCanvas
+        Canvas {
+            id: minuteCanvas
 
-        property real minute: 0
+            property real minute: 0
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.shadowBlur = parent.height * 0.00937; //3 px on 320x320
-            ctx.font = "24 " + height * 0.222 + "px Roboto";
-            ctx.fillText(twoDigits(minute), width * 0.642, height * 0.47);
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.shadowBlur = parent.height * 0.00937; //3 px on 320x320
+                ctx.font = "24 " + height * 0.222 + "px Roboto";
+                ctx.fillText(twoDigits(minute), width * 0.642, height * 0.47);
+            }
         }
-    }
 
-    Canvas {
-        id: secondCanvas
+        Canvas {
+            id: secondCanvas
 
-        property real second: 0
+            property real second: 0
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
-            ctx.textAlign = "right";
-            ctx.textBaseline = "right";
-            ctx.font = "22 " + height * 0.111 + "px Roboto";
-            ctx.fillText(twoDigits(second), width * 0.902, height * 0.419);
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
+                ctx.textAlign = "right";
+                ctx.textBaseline = "right";
+                ctx.font = "22 " + height * 0.111 + "px Roboto";
+                ctx.fillText(twoDigits(second), width * 0.902, height * 0.419);
+            }
         }
-    }
 
-    Canvas {
-        id: amPmCanvas
+        Canvas {
+            id: amPmCanvas
 
-        property bool am: false
+            property bool am: false
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        visible: use12H.value
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
-            ctx.textAlign = "right";
-            ctx.textBaseline = "right";
-            ctx.font = "14 " + height * 0.08 + "px Raleway";
-            ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "AP").slice(0, 2), width * 0.902, height * 0.5135);
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            visible: use12H.value
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
+                ctx.textAlign = "right";
+                ctx.textBaseline = "right";
+                ctx.font = "14 " + height * 0.08 + "px Raleway";
+                ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "AP").slice(0, 2), width * 0.902, height * 0.5135);
+            }
         }
-    }
 
-    Canvas {
-        id: monthCanvas
+        Canvas {
+            id: monthCanvas
 
-        property real date: 0
+            property real date: 0
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
-            ctx.textAlign = "center";
-            ctx.textBaseline = "middle";
-            var ctx = getContext("2d");
-            ctx.font = "20 " + height * 0.111 + "px Raleway";
-            ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase(), width * 0.642, height * 0.615);
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                var ctx = getContext("2d");
+                ctx.font = "20 " + height * 0.111 + "px Raleway";
+                ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase(), width * 0.642, height * 0.615);
+            }
         }
-    }
 
-    Canvas {
-        id: dateCanvas
+        Canvas {
+            id: dateCanvas
 
-        property real date: 0
+            property real date: 0
 
-        anchors.fill: parent
-        antialiasing: true
-        smooth: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
-            ctx.textAlign = "right";
-            ctx.textBaseline = "right";
-            var ctx = getContext("2d");
-            ctx.font = "42 " + height * 0.112 + "px Roboto";
-            ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "dd"), width * 0.902, height * 0.612);
+            anchors.fill: parent
+            antialiasing: true
+            smooth: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.shadowBlur = parent.height * 0.00625; //2 px on 320x320
+                ctx.textAlign = "right";
+                ctx.textBaseline = "right";
+                var ctx = getContext("2d");
+                ctx.font = "42 " + height * 0.112 + "px Roboto";
+                ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "dd"), width * 0.902, height * 0.612);
+            }
         }
+
     }
 
     Connections {

--- a/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
+++ b/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
@@ -6,7 +6,7 @@
 // Fixed am/pm display by slicing to two chars.
 // Calculated ctx.shadows with variable px size for better display in watchface-settings.
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     function twoDigits(x) {

--- a/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
+++ b/digital-alternative-default-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-default-mosen.qml
@@ -1,38 +1,10 @@
-/*
- * Copyright (C) 2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2017 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-/*
- * Based on Florents 000-default-digital stock watchface with added seconds.
- * Heavily quantizised to geometric proportions.
- * Fixed am/pm display by slicing to two chars.
- * Calculated ctx.shadows with variable px size for better display in watchface-settings
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
+// Based on Florent's 000-default-digital stock watchface with added seconds.
+// Heavily quantised to geometric proportions.
+// Fixed am/pm display by slicing to two chars.
+// Calculated ctx.shadows with variable px size for better display in watchface-settings.
 
 import QtQuick 2.9
 


### PR DESCRIPTION
## Summary

Geometric Canvas digital face based on Florent's stock default-digital, with added seconds display. The Canvas drawing logic and dirty-check repaint architecture are preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace BSD block comment with SPDX BSD-3-Clause format, correct moWerk handle, fix malformed nested block comment
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures all Canvas items fill a square region; prepareContext shadow calculations switched to faceBox.height
- **Fix Canvas font weight tokens** — replace arbitrary CSS weight numbers with standard values; Qt6 clamps unknown tokens to thin weight unlike Qt5 which ignored them

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): all Canvas text positions, font weights match original visual hierarchy, shadow rendering, AoD.