### PR TITLE
Refactor digital-alternative-mosen watchface for Qt6

### DIFF
--- a/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
+++ b/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
@@ -1,38 +1,10 @@
-/*
- * Copyright (C) 2019 - Timo Könnecke <github.com/moWerk>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-/*
-* Based on Florents 002-alternative-digital stock watchface.
-* Bigger monotype font (GeneraleMono) and fixed am/pm display by slicing to two chars.
-* Calculated ctx.shadows with variable px size for better display in watchface-settings
-*/
+// SPDX-FileCopyrightText: 2019 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
+// Based on Florent's 002-alternative-digital stock watchface.
+// Bigger monotype font (GeneraleMono) and fixed am/pm display by slicing to two chars.
+// Calculated ctx.shadows with variable px size for better display in watchface-settings.
 
 import QtQuick 2.9
 

--- a/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
+++ b/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
@@ -6,7 +6,7 @@
 // Bigger monotype font (GeneraleMono) and fixed am/pm display by slicing to two chars.
 // Calculated ctx.shadows with variable px size for better display in watchface-settings.
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     function prepareContext(ctx) {

--- a/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
+++ b/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
@@ -15,10 +15,12 @@ Item {
         ctx.textAlign = "center";
         ctx.textBaseline = 'middle';
         ctx.shadowColor = Qt.rgba(0, 0, 0, 0.8);
-        ctx.shadowOffsetX = parent.height * 0.00625;
-        ctx.shadowOffsetY = parent.height * 0.00625; //2 px on 320x320
-        ctx.shadowBlur = parent.height * 0.0156; //5 px on 320x320
+        ctx.shadowOffsetX = faceBox.height * 0.00625;
+        ctx.shadowOffsetY = faceBox.height * 0.00625;
+        ctx.shadowBlur = faceBox.height * 0.0156;
     }
+
+    anchors.fill: parent
 
     Component.onCompleted: {
         hourMinuteCanvas.requestPaint();
@@ -26,60 +28,69 @@ Item {
         amPmCanvas.requestPaint();
     }
 
-    Canvas {
-        id: hourMinuteCanvas
+    Item {
+        id: faceBox
 
-        anchors.fill: parent
-        antialiasing: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            var text;
-            if (use12H.value)
-                text = wallClock.time.toLocaleString(Qt.locale(), "hh:mm ap").substring(0, 5);
-            else
-                text = wallClock.time.toLocaleString(Qt.locale(), "HH:mm");
-            ctx.font = "50 " + parent.height * 0.25 + "px " + "GeneraleMono";
-            ctx.fillText(text, parent.width * 0.5, parent.height * 0.546);
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
+
+        Canvas {
+            id: hourMinuteCanvas
+
+            anchors.fill: parent
+            antialiasing: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                var text;
+                if (use12H.value)
+                    text = wallClock.time.toLocaleString(Qt.locale(), "hh:mm ap").substring(0, 5);
+                else
+                    text = wallClock.time.toLocaleString(Qt.locale(), "HH:mm");
+                ctx.font = "50 " + parent.height * 0.25 + "px " + "GeneraleMono";
+                ctx.fillText(text, parent.width * 0.5, parent.height * 0.546);
+            }
         }
-    }
 
-    Canvas {
-        id: amPmCanvas
+        Canvas {
+            id: amPmCanvas
 
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            var px = "px ";
-            var centerX = parent.width / 2;
-            var centerY = parent.height * 0.382;
-            var verticalOffset = -parent.height * 0.003;
-            var text;
-            text = wallClock.time.toLocaleString(Qt.locale(), "AP");
-            var fontSize = parent.height * 0.072;
-            var fontFamily = "GeneraleMono";
-            ctx.font = "0 " + fontSize + px + fontFamily;
-            if (use12H.value)
-                ctx.fillText(text, centerX, centerY + verticalOffset);
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                var px = "px ";
+                var centerX = parent.width / 2;
+                var centerY = parent.height * 0.382;
+                var verticalOffset = -parent.height * 0.003;
+                var text;
+                text = wallClock.time.toLocaleString(Qt.locale(), "AP");
+                var fontSize = parent.height * 0.072;
+                var fontFamily = "GeneraleMono";
+                ctx.font = "0 " + fontSize + px + fontFamily;
+                if (use12H.value)
+                    ctx.fillText(text, centerX, centerY + verticalOffset);
 
+            }
         }
-    }
 
-    Canvas {
-        id: dateCanvas
+        Canvas {
+            id: dateCanvas
 
-        anchors.fill: parent
-        antialiasing: true
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            prepareContext(ctx);
-            ctx.font = "0 " + parent.height * 0.0725 + "px " + "GeneraleMono";
-            ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "ddd dd MMM"), parent.width * 0.5, parent.height * 0.692);
+            anchors.fill: parent
+            antialiasing: true
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                prepareContext(ctx);
+                ctx.font = "0 " + parent.height * 0.0725 + "px " + "GeneraleMono";
+                ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "ddd dd MMM"), parent.width * 0.5, parent.height * 0.692);
+            }
         }
+
     }
 
     Connections {

--- a/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
+++ b/digital-alternative-mosen/usr/share/asteroid-launcher/watchfaces/digital-alternative-mosen.qml
@@ -21,7 +21,6 @@ Item {
     }
 
     anchors.fill: parent
-
     Component.onCompleted: {
         hourMinuteCanvas.requestPaint();
         dateCanvas.requestPaint();
@@ -49,7 +48,7 @@ Item {
                     text = wallClock.time.toLocaleString(Qt.locale(), "hh:mm ap").substring(0, 5);
                 else
                     text = wallClock.time.toLocaleString(Qt.locale(), "HH:mm");
-                ctx.font = "50 " + parent.height * 0.25 + "px " + "GeneraleMono";
+                ctx.font = "500 " + parent.height * 0.25 + "px GeneraleMono";
                 ctx.fillText(text, parent.width * 0.5, parent.height * 0.546);
             }
         }
@@ -70,7 +69,7 @@ Item {
                 text = wallClock.time.toLocaleString(Qt.locale(), "AP");
                 var fontSize = parent.height * 0.072;
                 var fontFamily = "GeneraleMono";
-                ctx.font = "0 " + fontSize + px + fontFamily;
+                ctx.font = "300 " + fontSize + px + fontFamily;
                 if (use12H.value)
                     ctx.fillText(text, centerX, centerY + verticalOffset);
 
@@ -86,7 +85,7 @@ Item {
             onPaint: {
                 var ctx = getContext("2d");
                 prepareContext(ctx);
-                ctx.font = "0 " + parent.height * 0.0725 + "px " + "GeneraleMono";
+                ctx.font = "300 " + parent.height * 0.0725 + "px GeneraleMono";
                 ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "ddd dd MMM"), parent.width * 0.5, parent.height * 0.692);
             }
         }


### PR DESCRIPTION
## Summary

Monotype GeneraleMono digital face based on Florent's stock alternative-digital. The Canvas drawing logic is preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace BSD block comment with SPDX BSD-3-Clause format, convert design description to // lines
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures Canvas items fill a square region; prepareContext shadow calculations switched to faceBox.height
- **Fix Canvas font weight tokens** — replace invalid CSS weight numbers with standard values; Qt6 clamps unknown tokens to thin weight unlike Qt5

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): hour/minute display weight and size, am/pm and date at lighter weight, shadow rendering, locale change repaint via localeManager, AoD.