### PR TITLE
Refactor digital-charge-state watchface for Qt6

### DIFF
--- a/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
+++ b/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
@@ -1,20 +1,5 @@
-/*
- * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce 1.0
 import QtQuick 2.15

--- a/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
+++ b/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
@@ -133,15 +133,16 @@ Item {
     }
 
     Connections {
-        target: wallClock
-        onTimeChanged: {
+        function onTimeChanged() {
             if (!visible)
-                return ;
+                return;
 
             datetext.text = wallClock.time.toLocaleString(Qt.locale(), "ddd dd");
             time.text = wallClock.time.toLocaleString(Qt.locale(), use12H.value ? "hhmm ap" : "HHmm").slice(0, 4);
             ampm.text = wallClock.time.toLocaleString(Qt.locale(), "ap");
         }
+
+        target: wallClock
     }
 
 }

--- a/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
+++ b/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
@@ -104,17 +104,17 @@ Item {
         ShapePath {
             fillColor: "transparent"
             strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-            strokeWidth: parent.height * 0.02
+            strokeWidth: chargeArc.height * 0.02
             capStyle: ShapePath.RoundCap
             joinStyle: ShapePath.RoundJoin
-            startX: width / 2
-            startY: height * (0.5 - chargeArc.scalefactor)
+            startX: chargeArc.width / 2
+            startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
             PathAngleArc {
-                centerX: parent.width / 2
-                centerY: parent.height / 2
-                radiusX: chargeArc.scalefactor * parent.width
-                radiusY: chargeArc.scalefactor * parent.height
+                centerX: chargeArc.width / 2
+                centerY: chargeArc.height / 2
+                radiusX: chargeArc.scalefactor * chargeArc.width
+                radiusY: chargeArc.scalefactor * chargeArc.height
                 startAngle: -90
                 sweepAngle: chargeArc.angle
                 moveToStart: false

--- a/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
+++ b/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Nemo.Mce 1.0
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import Nemo.Mce
+import QtQuick
+import QtQuick.Shapes
+import org.asteroid.controls
+import org.asteroid.utils
 
 Item {
     Component.onCompleted: {

--- a/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
+++ b/digital-charge-state/usr/share/asteroid-launcher/watchfaces/digital-charge-state.qml
@@ -8,134 +8,146 @@ import org.asteroid.controls
 import org.asteroid.utils
 
 Item {
+    id: root
+
+    anchors.fill: parent
     Component.onCompleted: {
         datetext.text = wallClock.time.toLocaleString(Qt.locale(), "ddd dd");
         time.text = wallClock.time.toLocaleString(Qt.locale(), use12H.value ? "hhmm ap" : "HHmm").slice(0, 4);
         ampm.text = wallClock.time.toLocaleString(Qt.locale(), "ap");
     }
 
-    Icon {
-        id: batteryIcon
+    Item {
+        id: faceBox
 
-        name: "ios-battery-charging"
-        visible: batteryChargeState.value === MceBatteryState.Charging
-        width: parent.width * 0.2
-        height: parent.height * 0.2
-        opacity: displayAmbient ? 0.4 : 0.9
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: -parent.height * 0.272
-        }
+        Icon {
+            id: batteryIcon
 
-    }
+            name: "ios-battery-charging"
+            visible: batteryChargeState.value === MceBatteryState.Charging
+            width: parent.width * 0.2
+            height: parent.height * 0.2
+            opacity: displayAmbient ? 0.4 : 0.9
 
-    Text {
-        id: datetext
-
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), "ddd dd")
-
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: parent.height * 0.25
-        }
-
-        font {
-            family: "Titillium"
-            weight: Font.Thin
-            pixelSize: parent.height * 0.06
-        }
-
-    }
-
-    Text {
-        id: time
-
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), (use12H.value ? "hhmm ap" : "HHmm")).slice(0, 4)
-
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: parent.height * 0.02
-        }
-
-        font {
-            family: "Titillium"
-            weight: Font.Thin
-            pixelSize: parent.height * 0.3
-        }
-
-    }
-
-    Text {
-        id: ampm
-
-        visible: use12H.value
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), "ap")
-
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: parent.height * 0.143
-        }
-
-        font {
-            family: "Titillium"
-            weight: Font.Bold
-            pixelSize: parent.height * 0.05
-        }
-
-    }
-
-    Shape {
-        id: chargeArc
-
-        property real angle: batteryChargePercentage.percent * 360 / 100
-        // radius of arc is scalefactor * height or width
-        property real scalefactor: 0.46
-        property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-        readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
-
-        visible: true // batteryChargeState.value == MceBatteryState.Charging
-        opacity: displayAmbient ? 0.5 : 1
-        anchors.fill: parent
-
-        ShapePath {
-            fillColor: "transparent"
-            strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-            strokeWidth: chargeArc.height * 0.02
-            capStyle: ShapePath.RoundCap
-            joinStyle: ShapePath.RoundJoin
-            startX: chargeArc.width / 2
-            startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
-
-            PathAngleArc {
-                centerX: chargeArc.width / 2
-                centerY: chargeArc.height / 2
-                radiusX: chargeArc.scalefactor * chargeArc.width
-                radiusY: chargeArc.scalefactor * chargeArc.height
-                startAngle: -90
-                sweepAngle: chargeArc.angle
-                moveToStart: false
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: -parent.height * 0.272
             }
 
         }
 
-    }
+        Text {
+            id: datetext
 
-    MceBatteryLevel {
-        id: batteryChargePercentage
-    }
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), "ddd dd")
 
-    MceBatteryState {
-        id: batteryChargeState
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: parent.height * 0.25
+            }
+
+            font {
+                family: "Titillium"
+                weight: Font.Thin
+                pixelSize: parent.height * 0.06
+            }
+
+        }
+
+        Text {
+            id: time
+
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), (use12H.value ? "hhmm ap" : "HHmm")).slice(0, 4)
+
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: -parent.height * 0.02
+            }
+
+            font {
+                family: "Titillium"
+                weight: Font.Thin
+                pixelSize: parent.height * 0.3
+            }
+
+        }
+
+        Text {
+            id: ampm
+
+            visible: use12H.value
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), "ap")
+
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: parent.height * 0.143
+            }
+
+            font {
+                family: "Titillium"
+                weight: Font.Bold
+                pixelSize: parent.height * 0.05
+            }
+
+        }
+
+        Shape {
+            id: chargeArc
+
+            property real angle: batteryChargePercentage.percent * 360 / 100
+            // radius of arc is scalefactor * height or width
+            property real scalefactor: 0.46
+            property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+            readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
+
+            visible: true // batteryChargeState.value == MceBatteryState.Charging
+            opacity: displayAmbient ? 0.5 : 1
+            anchors.fill: parent
+
+            ShapePath {
+                fillColor: "transparent"
+                strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
+                strokeWidth: chargeArc.height * 0.02
+                capStyle: ShapePath.RoundCap
+                joinStyle: ShapePath.RoundJoin
+                startX: chargeArc.width / 2
+                startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
+
+                PathAngleArc {
+                    centerX: chargeArc.width / 2
+                    centerY: chargeArc.height / 2
+                    radiusX: chargeArc.scalefactor * chargeArc.width
+                    radiusY: chargeArc.scalefactor * chargeArc.height
+                    startAngle: -90
+                    sweepAngle: chargeArc.angle
+                    moveToStart: false
+                }
+
+            }
+
+        }
+
+        MceBatteryLevel {
+            id: batteryChargePercentage
+        }
+
+        MceBatteryState {
+            id: batteryChargeState
+        }
+
     }
 
     Connections {
         function onTimeChanged() {
             if (!visible)
-                return;
+                return ;
 
             datetext.text = wallClock.time.toLocaleString(Qt.locale(), "ddd dd");
             time.text = wallClock.time.toLocaleString(Qt.locale(), use12H.value ? "hhmm ap" : "HHmm").slice(0, 4);


### PR DESCRIPTION
## Summary

Beroset's nightstand charging display face. Conservative pass — layout and charge arc design preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 import fix** — drop version suffixes from all imports
- **Convert Connections to Qt6 syntax** — function handler format, target moved to bottom
- **Fix chargeArc PathAngleArc** — replace parent references with chargeArc id in ShapePath and PathAngleArc
- **Add square geometry guard** — faceBox container ensures correct rendering on non-square panels
- **Fix time text vertical centering** — reverse verticalCenterOffset sign to compensate for Qt6 bounding box regression

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): circular charge arc, time text visually centred, text positions, battery icon, AoD.

## Notes

The verticalCenterOffset sign reversal is a Qt6 bounding box compensation, not a design change. Please confirm the square geometry and arc changes match your intent.