### PR TITLE
Refactor digital-kerning-panic watchface for Qt6

### DIFF
--- a/digital-kerning-panic/usr/share/asteroid-launcher/watchfaces/digital-kerning-panic.qml
+++ b/digital-kerning-panic/usr/share/asteroid-launcher/watchfaces/digital-kerning-panic.qml
@@ -25,7 +25,7 @@ Item {
         var sec = wallClock.time.getSeconds();
         hh.text = root.pad(h);
         mm.text = root.pad(min);
-        hh.wobbleOffset = Math.sin(sec * Math.PI / 30) * (root.width * 0.018);
+        hh.wobbleOffset = Math.sin(sec * Math.PI / 30) * (watchfaceRoot.width * 0.018);
         mm.wobbleOffset = hh.wobbleOffset;
         dowText.text = wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase();
         dateText.text = root.pad(wallClock.time.getDate()) + " " + wallClock.time.toLocaleString(Qt.locale(), "MMM").toUpperCase();
@@ -55,8 +55,8 @@ Item {
 
             font {
                 family: "Space Mono"
-                pixelSize: root.height * 0.05
-                letterSpacing: root.width * 0.018
+                pixelSize: watchfaceRoot.height * 0.05
+                letterSpacing: watchfaceRoot.width * 0.018
             }
 
         }
@@ -90,7 +90,7 @@ Item {
 
                 font {
                     family: "Bungee"
-                    pixelSize: root.height * 0.32
+                    pixelSize: watchfaceRoot.height * 0.32
                 }
 
                 Behavior on wobbleOffset {
@@ -120,7 +120,7 @@ Item {
 
                 font {
                     family: "Bungee"
-                    pixelSize: root.height * 0.32
+                    pixelSize: watchfaceRoot.height * 0.32
                 }
 
                 Behavior on wobbleOffset {
@@ -174,7 +174,7 @@ Item {
 
             font {
                 family: "Space Mono"
-                pixelSize: root.height * 0.05
+                pixelSize: watchfaceRoot.height * 0.05
                 letterSpacing: 2
             }
 
@@ -198,7 +198,7 @@ Item {
             var h = wallClock.time.getHours();
             var min = wallClock.time.getMinutes();
             var sec = wallClock.time.getSeconds();
-            var wobble = displayAmbient ? 0 : Math.sin(sec * Math.PI / 30) * (root.width * 0.04);
+            var wobble = displayAmbient ? 0 : Math.sin(sec * Math.PI / 30) * (watchfaceRoot.width * 0.04);
             hh.text = root.pad(h);
             mm.text = root.pad(min);
             hh.wobbleOffset = wobble;

--- a/digital-kerning-panic/usr/share/asteroid-launcher/watchfaces/digital-kerning-panic.qml
+++ b/digital-kerning-panic/usr/share/asteroid-launcher/watchfaces/digital-kerning-panic.qml
@@ -1,15 +1,13 @@
-/*
- * Typographic joke. Big Bungee HH, smaller MM wedged against it. Every
- * second the digits visibly shove sideways (NumberAnimation easing)
- * — time as a kerning problem. Seconds progress bar runs beneath.
- * Weekday stands vertical in the left margin.
- *
- * Fonts: Bungee (OFL), Space Mono (OFL)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+// Kerning Panic — AsteroidOS watchface
+// Typographic joke. Big Bungee HH, smaller MM wedged against it. Every
+// second the digits visibly shove sideways (NumberAnimation easing)
+// — time as a kerning problem. Seconds progress bar runs beneath.
+// Weekday stands vertical in the left margin.
+// Fonts: Bungee (OFL), Space Mono (OFL)
 
-import QtQuick 2.15
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Recently written typographic face. Minimal changes needed.

## Commits

- **Move design comment and drop import version** — convert block comment to // line format below SPDX header, drop QtQuick version suffix
- **Fix font sizes and wobble to watchfaceRoot dimensions** — replace root.height/width with watchfaceRoot equivalents so digit sizes and animation scale correctly on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): digit sizing, kerning wobble animation, seconds bar, vertical weekday label, AoD.