### PR TITLE
Refactor digital-led watchface for Qt6

### DIFF
--- a/digital-led/usr/share/asteroid-launcher/watchfaces/digital-led.qml
+++ b/digital-led/usr/share/asteroid-launcher/watchfaces/digital-led.qml
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 ncaat <github.com/ncaat>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.9
+import QtQuick
 
 Rectangle {
     id: root

--- a/digital-led/usr/share/asteroid-launcher/watchfaces/digital-led.qml
+++ b/digital-led/usr/share/asteroid-launcher/watchfaces/digital-led.qml
@@ -1,20 +1,5 @@
-/*
- * Copyright (C) 2026 - ncaat <github.com/ncaat>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2026 ncaat <github.com/ncaat>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.9
 


### PR DESCRIPTION
## Summary

Dot-matrix LED clock built entirely from Rectangles via nested Component/Loader/Repeater architecture. Minimal changes — the rendering system is already self-centering and scales correctly on non-square panels via dotSize: width * 0.01.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 import fix** — drop QtQuick version suffix

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): dot matrix digits centred correctly, AoD.