### PR TITLE
Refactor digital-namazu-no-henka watchface for Qt6

### DIFF
--- a/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
+++ b/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
@@ -1,27 +1,11 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2022 - Timo Könnecke <github.com/eLtMosen>
- *               2021 - Darrel Griët <dgriet@gmail.com>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2021 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce 1.0
 import QtGraphicalEffects 1.15

--- a/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
+++ b/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
@@ -7,10 +7,10 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Shapes
 
 Item {
     id: root

--- a/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
+++ b/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
@@ -280,17 +280,17 @@ Item {
                 ShapePath {
                     fillColor: "transparent"
                     strokeColor: "green"
-                    strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                    strokeWidth: segment.height * segmentedArc.arcStrokeWidth
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
-                    startX: parent.width / 2
-                    startY: parent.height * (0.5 - segmentedArc.scalefactor)
+                    startX: segment.width / 2
+                    startY: segment.height * (0.5 - segmentedArc.scalefactor)
 
                     PathAngleArc {
-                        centerX: parent.width / 2
-                        centerY: parent.height / 2
-                        radiusX: segmentedArc.scalefactor * parent.width
-                        radiusY: segmentedArc.scalefactor * parent.height
+                        centerX: segment.width / 2
+                        centerY: segment.height / 2
+                        radiusX: segmentedArc.scalefactor * segment.width
+                        radiusY: segmentedArc.scalefactor * segment.height
                         startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
                         sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                         moveToStart: true

--- a/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
+++ b/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
@@ -16,10 +16,11 @@ Item {
     id: root
 
     property string imgPath: "../watchfaces-img/digital-namazu-no-henka-"
-    property var largeNumeralSize: Qt.size(parent.width * 0.25, parent.height * 0.25)
-    property var smallNumeralSize: Qt.size(parent.width * 0.076, parent.height * 0.076)
-    property real largeNumeralOffset: -parent.height * 0.02
-    property real smallNumeralOffset: parent.height * 0.0606
+    property real maxSize: Math.min(width, height)
+    property var largeNumeralSize: Qt.size(maxSize * 0.25, maxSize * 0.25)
+    property var smallNumeralSize: Qt.size(maxSize * 0.076, maxSize * 0.076)
+    property real largeNumeralOffset: -maxSize * 0.02
+    property real smallNumeralOffset: maxSize * 0.0606
     property string hour: wallClock.time.toLocaleString(Qt.locale(), "HH")
     property string minute: wallClock.time.toLocaleString(Qt.locale(), "mm")
     property string month: wallClock.time.toLocaleString(Qt.locale(), "MM")
@@ -31,6 +32,7 @@ Item {
         return num;
     }
 
+    anchors.fill: parent
     layer.enabled: true
 
     MceBatteryLevel {
@@ -50,7 +52,7 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: -parent.height * 0.01
+                rightMargin: -maxSize * 0.01
                 bottom: parent.verticalCenter
                 bottomMargin: largeNumeralOffset
             }
@@ -65,7 +67,7 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: (-parent.height * 0.01) + (parent.height * 0.165)
+                rightMargin: (-maxSize * 0.01) + (maxSize * 0.165)
                 bottom: parent.verticalCenter
                 bottomMargin: largeNumeralOffset
             }
@@ -94,7 +96,7 @@ Item {
 
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: (parent.height * 0.155) + (-parent.height * 0.165)
+                leftMargin: (maxSize * 0.155) + (-maxSize * 0.165)
                 bottom: parent.verticalCenter
                 bottomMargin: largeNumeralOffset
             }
@@ -109,7 +111,7 @@ Item {
 
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: parent.height * 0.157
+                leftMargin: maxSize * 0.157
                 bottom: parent.verticalCenter
                 bottomMargin: largeNumeralOffset
             }
@@ -131,7 +133,7 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: parent.height * 0.288
+                rightMargin: maxSize * 0.288
                 top: parent.verticalCenter
                 topMargin: smallNumeralOffset
             }
@@ -146,7 +148,7 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: parent.height * 0.229
+                rightMargin: maxSize * 0.229
                 top: parent.verticalCenter
                 topMargin: smallNumeralOffset
             }
@@ -161,7 +163,7 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: parent.height * 0.17
+                rightMargin: maxSize * 0.17
                 top: parent.verticalCenter
                 topMargin: smallNumeralOffset
             }
@@ -176,7 +178,7 @@ Item {
 
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: -parent.height * 0.187
+                leftMargin: -maxSize * 0.187
                 top: parent.verticalCenter
                 topMargin: smallNumeralOffset
             }
@@ -191,7 +193,7 @@ Item {
 
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: -parent.height * 0.127
+                leftMargin: -maxSize * 0.127
                 top: parent.verticalCenter
                 topMargin: smallNumeralOffset
             }
@@ -215,9 +217,9 @@ Item {
 
             anchors {
                 right: parent.horizontalCenter
-                rightMargin: parent.height * 0.021
+                rightMargin: maxSize * 0.021
                 top: parent.verticalCenter
-                topMargin: parent.height * 0.3
+                topMargin: maxSize * 0.3
             }
 
         }
@@ -231,7 +233,7 @@ Item {
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: parent.verticalCenter
-                topMargin: parent.height * 0.3
+                topMargin: maxSize * 0.3
             }
 
         }
@@ -244,9 +246,9 @@ Item {
 
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: parent.height * 0.021
+                leftMargin: maxSize * 0.021
                 top: parent.verticalCenter
-                topMargin: parent.height * 0.3
+                topMargin: maxSize * 0.3
             }
 
         }
@@ -275,6 +277,7 @@ Item {
             Shape {
                 id: segment
 
+                anchors.fill: parent
                 visible: index === 0 ? true : (index / segmentedArc.segmentAmount) <= (segmentedArc.inputValue - 0.1)
 
                 ShapePath {

--- a/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
+++ b/digital-namazu-no-henka/usr/share/asteroid-launcher/watchfaces/digital-namazu-no-henka.qml
@@ -258,12 +258,6 @@ Item {
 
         anchors.fill: parent
 
-        layer {
-            enabled: true
-            samples: 4
-            textureSize: Qt.size(root.width * 2, root.height * 2)
-        }
-
         Repeater {
             id: segmentedArc
 


### PR DESCRIPTION
## Summary

Pixel-accurate catfish secondary display recreation designed for a seamless transition to the homescreen. The root DropShadow is preserved as an intentional design element. All numeral and segment positioning preserved in spirit — only dimension source corrected to maxSize.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate erroneous 2026 entry into correct 2022 moWerk line
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes, reorder alphabetically
- **Remove batterySegments layer block** — layer.samples not supported on hardware; Shape renders correctly via RHI without it
- **Fix ShapePath and PathAngleArc parent resolution** — replace parent with segment id throughout
- **Fix square geometry** — anchors.fill on root, maxSize property, all parent.height offset references switched to maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): numeral sizing and positioning, battery arc segments, DropShadow preserved, AoD.