### PR TITLE
Refactor digital-night-stand-outfit watchface for Qt6

### DIFF
--- a/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
+++ b/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
@@ -9,12 +9,11 @@ import org.asteroid.controls
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
     property real rad: 0.01745
     property string userColor: "#65AFFF" // green: #9BE564 / orange: #EA9010 / blue: #65AFFF
 
-    anchors.centerIn: parent
-    width: parent.width
-    height: parent.height
+    anchors.fill: parent
     layer.enabled: true
 
     MceBatteryLevel {
@@ -28,8 +27,8 @@ Item {
 
         onValueChanged: batteryArc.requestPaint()
         anchors.centerIn: parent
-        width: parent.width * 0.85
-        height: parent.height * 0.88
+        width: root.maxSize * 0.85
+        height: root.maxSize * 0.88
 
         Canvas {
             id: batteryArc
@@ -39,7 +38,7 @@ Item {
             onPaint: {
                 var ctx = getContext("2d");
                 ctx.reset();
-                ctx.lineWidth = root.height * 0.009;
+                ctx.lineWidth = root.maxSize * 0.009;
                 ctx.lineCap = "round";
                 ctx.strokeStyle = userColor;
                 ctx.beginPath();
@@ -59,11 +58,11 @@ Item {
 
             anchors {
                 centerIn: parent
-                verticalCenterOffset: -root.height * 0.21
+                verticalCenterOffset: -root.maxSize * 0.21
             }
 
             font {
-                pixelSize: root.height * 0.12
+                pixelSize: root.maxSize * 0.12
                 family: "Outfit"
                 styleName: "Light"
             }

--- a/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
+++ b/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.1
-import org.asteroid.controls 1.0
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import org.asteroid.controls
 
 Item {
     id: root

--- a/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
+++ b/digital-night-stand-outfit/usr/share/asteroid-launcher/watchfaces/digital-night-stand-outfit.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce 1.0
 import QtGraphicalEffects 1.15


### PR DESCRIPTION
## Summary

Nightstand charging face with Outfit font and configurable accent colour. The root DropShadow is preserved as an intentional design element.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct eLtMosen handle to moWerk
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes, reorder alphabetically
- **Fix square geometry** — anchors.fill on root, maxSize property, all root.height references switched to root.maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): battery arc, time display centred, date and am/pm text, DropShadow preserved, AoD.