### PR TITLE
Refactor digital-noto-seconds watchface for Qt6

### DIFF
--- a/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
+++ b/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
@@ -9,8 +9,10 @@ import QtQuick
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
     property real arcEnd: wallClock.time.getSeconds() * 6
 
+    anchors.fill: parent
     onArcEndChanged: seconds.requestPaint()
     layer.enabled: true
 
@@ -18,19 +20,21 @@ Item {
         id: seconds
 
         visible: !displayAmbient
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
         rotation: -90
         onPaint: {
             var ctx = getContext("2d");
-            var x = root.width / 2;
-            var y = root.height / 2;
+            var x = width / 2;
+            var y = height / 2;
             var start = 0;
             var end = Math.PI * (parent.arcEnd / 180);
             ctx.reset();
             ctx.beginPath();
             ctx.lineCap = "round";
-            ctx.arc(x, y, (root.width / 2) - parent.height * 0.124 / 2, start, end, false);
-            ctx.lineWidth = parent.height * 0.03;
+            ctx.arc(x, y, (width / 2) - height * 0.124 / 2, start, end, false);
+            ctx.lineWidth = height * 0.03;
             ctx.strokeStyle = "#CCC";
             ctx.stroke();
         }
@@ -45,14 +49,14 @@ Item {
         text: ":"
 
         font {
-            pixelSize: root.height * 0.28
+            pixelSize: root.maxSize * 0.27
             family: "Noto Sans"
         }
 
         anchors {
             centerIn: root
             horizontalCenterOffset: root.width * 0.01
-            verticalCenterOffset: root.width * -0.05
+            verticalCenterOffset: root.width * -0.03
         }
 
     }
@@ -67,8 +71,8 @@ Item {
         text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
 
         font {
-            pixelSize: root.height * 0.25
-            letterSpacing: root.height * 0.004
+            pixelSize: root.maxSize * 0.24
+            letterSpacing: root.maxSize * 0.004
             family: "Noto Sans"
         }
 
@@ -88,8 +92,8 @@ Item {
         text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
         font {
-            pixelSize: root.height * 0.25
-            letterSpacing: root.height * 0.004
+            pixelSize: root.maxSize * 0.24
+            letterSpacing: root.maxSize * 0.004
             family: "Noto Sans"
         }
 
@@ -109,15 +113,15 @@ Item {
         text: wallClock.time.toLocaleString(Qt.locale(), "ddd, MMM dd").replace(".", "")
 
         font {
-            pixelSize: root.height * 0.07
-            letterSpacing: root.height * 0.006
+            pixelSize: root.maxSize * 0.07
+            letterSpacing: root.maxSize * 0.006
             family: "Noto Sans"
         }
 
         anchors {
             horizontalCenter: root.horizontalCenter
             top: colon.bottom
-            topMargin: root.height * -0.04
+            topMargin: root.maxSize * -0.04
         }
 
     }

--- a/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
+++ b/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
@@ -1,22 +1,6 @@
-/*
- * Copyright (C) 2022 - Commenter25 <github.com/Commenter25>
- * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Commenter25 <github.com/Commenter25>
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 // based off digital-shifted
 
 import QtGraphicalEffects 1.15

--- a/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
+++ b/digital-noto-seconds/usr/share/asteroid-launcher/watchfaces/digital-noto-seconds.qml
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // based off digital-shifted
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Seconds arc face by Commenter25 based on digital-shifted. The root DropShadow is preserved as an intentional design element. Conservative pass.

## Commits

- **Convert SPDX header** — replace legacy block comments with SPDX one-liner format, correct moWerk handle
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes
- **Fix square geometry** — anchors.fill on root, maxSize property, root.height references switched to root.maxSize throughout

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): seconds arc geometry, time and date text sizes, DropShadow preserved, AoD.

## Notes

Please confirm the square geometry change matches your intent.