### PR TITLE
Refactor digital-numeral-unity watchface for Qt6

### DIFF
--- a/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
+++ b/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.9

--- a/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
+++ b/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
@@ -7,11 +7,13 @@ import QtQuick
 Item {
     id: root
 
-    property real topbottomMargin: root.height * 0.022
-    property real leftrightMargin: -root.height * 0.018
-    property var numeralSize: Qt.size(root.width * 0.32, root.height * 0.32)
+    property real maxSize: Math.min(width, height)
+    property real topbottomMargin: maxSize * 0.022
+    property real leftrightMargin: -maxSize * 0.018
+    property var numeralSize: Qt.size(maxSize * 0.32, maxSize * 0.32)
     property string imagePath: "../watchfaces-img/digital-numeral-unity-"
 
+    anchors.fill: parent
     layer.enabled: true
 
     Image {

--- a/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
+++ b/digital-numeral-unity/usr/share/asteroid-launcher/watchfaces/digital-numeral-unity.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

SVG numeral demo face with cyan glow DropShadow. The root layer glow is preserved as the defining design element.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2021
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes
- **Fix square geometry** — anchors.fill on root, maxSize property, margin and numeral size references switched to maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): square numeral sizing, correct margins, cyan glow preserved, AoD.