### PR TITLE
Refactor digital-nutty-null watchface for Qt6

### DIFF
--- a/digital-nutty-null/usr/share/asteroid-launcher/watchfaces/digital-nutty-null.qml
+++ b/digital-nutty-null/usr/share/asteroid-launcher/watchfaces/digital-nutty-null.qml
@@ -8,7 +8,7 @@
 // Native QML only — no Canvas.
 // Font: Inter Tight (SIL OFL 1.1)
 
-import QtGraphicalEffects
+import Qt5Compat.GraphicalEffects
 import QtQuick
 
 Item {
@@ -19,6 +19,7 @@ Item {
     property int h12: 12
     property real angleRad: 0
     readonly property real rootRadius: Math.min(width, height) * 0.41
+    readonly property real maxSize: Math.min(width, height)
     readonly property color fg: Qt.rgba(1, 1, 1, displayAmbient ? 0.75 : 1)
     readonly property color dim: Qt.rgba(1, 1, 1, displayAmbient ? 0.45 : 0.7)
 
@@ -47,8 +48,8 @@ Item {
         font {
             family: "Inter Tight"
             weight: Font.Thin
-            pixelSize: root.height * 0.5
-            letterSpacing: -root.height * 0.03
+            pixelSize: root.maxSize * 0.5
+            letterSpacing: -root.maxSize * 0.03
         }
 
     }
@@ -72,7 +73,7 @@ Item {
             font {
                 family: "Inter Tight"
                 weight: dist === 0 ? Font.Medium : Font.Light
-                pixelSize: root.height * 0.1
+                pixelSize: root.maxSize * 0.1
             }
 
         }
@@ -95,8 +96,8 @@ Item {
         font {
             family: "Inter Tight"
             weight: Font.Light
-            pixelSize: root.height * 0.054
-            letterSpacing: root.height * 0.012
+            pixelSize: root.maxSize * 0.054
+            letterSpacing: root.maxSize * 0.012
         }
 
     }

--- a/digital-nutty-null/usr/share/asteroid-launcher/watchfaces/digital-nutty-null.qml
+++ b/digital-nutty-null/usr/share/asteroid-launcher/watchfaces/digital-nutty-null.qml
@@ -1,4 +1,3 @@
-// Font: Inter Tight (SIL OFL 1.1)
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
 // Nutty Null — AsteroidOS watchface
@@ -7,6 +6,7 @@
 // 3 at the 3 o'clock mark, 9 at the 9 o'clock mark. You read the
 // hour as position, the minute as number.
 // Native QML only — no Canvas.
+// Font: Inter Tight (SIL OFL 1.1)
 
 import QtGraphicalEffects
 import QtQuick


### PR DESCRIPTION
## Summary

Recently written face, nearly Qt6-ready. Two small fixes only.

## Commits

- **Move font attribution below SPDX header** — Font: line was above the copyright lines
- **Fix font sizes for non-square screens** — root.height references switched to root.maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): minute numeral sizing, hour position ring, date text, AoD.