### PR TITLE
Refactor digital-shifted watchface for Qt6

### DIFF
--- a/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
+++ b/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.9

--- a/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
+++ b/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
@@ -129,13 +129,16 @@ Item {
             id: dowDisplay
 
             visible: !displayAmbient
-            font.pixelSize: parent.height * 0.06
-            font.family: "Open Sans"
-            font.styleName: "Condensed Light"
-            font.letterSpacing: -parent.height * 0.0006
             color: "#ddffffff"
             horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
+
+            font {
+                pixelSize: parent.height * 0.06
+                family: "Open Sans"
+                styleName: "Condensed Light"
+                letterSpacing: -parent.height * 0.0006
+            }
 
             anchors {
                 left: topCenter.right
@@ -150,13 +153,16 @@ Item {
             id: apDisplay
 
             visible: !displayAmbient
-            font.pixelSize: parent.height * 0.1
-            font.family: "Open Sans"
-            font.styleName: "Light"
-            font.letterSpacing: -parent.height * 0.006
             color: "#ddffffff"
             horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ap</b>").toUpperCase()
+
+            font {
+                pixelSize: parent.height * 0.1
+                family: "Open Sans"
+                styleName: "Light"
+                letterSpacing: -parent.height * 0.006
+            }
 
             anchors {
                 left: topCenter.right
@@ -171,13 +177,16 @@ Item {
             id: monthDisplay
 
             visible: !displayAmbient
-            font.pixelSize: parent.height * 0.06
-            font.family: "Open Sans"
-            font.styleName: "Condensed Light"
-            font.letterSpacing: -parent.height * 0.0006
             color: "#ddffffff"
             horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "MMMM").toUpperCase()
+
+            font {
+                pixelSize: parent.height * 0.06
+                family: "Open Sans"
+                styleName: "Condensed Light"
+                letterSpacing: -parent.height * 0.0006
+            }
 
             anchors {
                 right: bottomCenter.left
@@ -193,13 +202,16 @@ Item {
 
             z: 2
             visible: !displayAmbient
-            font.pixelSize: parent.height * 0.122
-            font.family: "Open Sans"
-            font.styleName: "Light"
-            font.letterSpacing: -parent.height * 0.008
             color: "#ddffffff"
             horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "dd").toUpperCase()
+
+            font {
+                pixelSize: parent.height * 0.122
+                family: "Open Sans"
+                styleName: "Light"
+                letterSpacing: -parent.height * 0.008
+            }
 
             anchors {
                 right: bottomCenter.left

--- a/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
+++ b/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
@@ -7,12 +7,13 @@ import QtQuick
 Item {
     id: root
 
-    property real topbottomMargin: parent.height * 0.0086
-    property real leftrightMargin: -parent.height * 0.048
-    property size numeralSize: Qt.size(parent.width * 0.25, parent.height * 0.25)
+    property real maxSize: Math.min(width, height)
+    property real topbottomMargin: maxSize * 0.0086
+    property real leftrightMargin: -maxSize * 0.048
+    property size numeralSize: Qt.size(maxSize * 0.25, maxSize * 0.25)
     property real arcEnd: wallClock.time.getSeconds() * 6
 
-    // Fire requestPaint once per second on tick, not on every animation frame.
+    anchors.fill: parent
     onArcEndChanged: canvas.requestPaint()
 
     Image {
@@ -21,28 +22,30 @@ Item {
         z: 0
         visible: !displayAmbient
         source: "../watchfaces-img/digital-shifted-ring.svg"
+        width: root.maxSize
+        height: root.maxSize
         anchors.centerIn: parent
-        width: parent.width
-        height: parent.height
     }
 
     Canvas {
         id: canvas
 
         visible: !displayAmbient
-        anchors.fill: parent
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
         rotation: -90
         onPaint: {
             var ctx = getContext("2d");
-            var x = root.width / 2;
-            var y = root.height / 2;
+            var x = width / 2;
+            var y = height / 2;
             var start = 0;
             var end = Math.PI * (root.arcEnd / 180);
             ctx.reset();
             ctx.beginPath();
             ctx.lineCap = "round";
-            ctx.arc(x, y, (root.width / 2) - parent.height * 0.124 / 2, start, end, false);
-            ctx.lineWidth = parent.height * 0.03;
+            ctx.arc(x, y, (width / 2) - height * 0.124 / 2, start, end, false);
+            ctx.lineWidth = height * 0.03;
             ctx.strokeStyle = "#7738FF12";
             ctx.stroke();
         }
@@ -60,9 +63,9 @@ Item {
     }
 
     Item {
+        width: root.maxSize
+        height: root.maxSize
         anchors.centerIn: parent
-        width: parent.width
-        height: parent.height
         layer.enabled: true
 
         Image {

--- a/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
+++ b/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
@@ -19,7 +19,6 @@ Item {
     Image {
         id: ring
 
-        z: 0
         visible: !displayAmbient
         source: "../watchfaces-img/digital-shifted-ring.svg"
         width: root.maxSize
@@ -129,7 +128,6 @@ Item {
         Text {
             id: dowDisplay
 
-            z: 2
             visible: !displayAmbient
             font.pixelSize: parent.height * 0.06
             font.family: "Open Sans"
@@ -151,7 +149,6 @@ Item {
         Text {
             id: apDisplay
 
-            z: 2
             visible: !displayAmbient
             font.pixelSize: parent.height * 0.1
             font.family: "Open Sans"
@@ -173,7 +170,6 @@ Item {
         Text {
             id: monthDisplay
 
-            z: 2
             visible: !displayAmbient
             font.pixelSize: parent.height * 0.06
             font.family: "Open Sans"

--- a/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
+++ b/digital-shifted/usr/share/asteroid-launcher/watchfaces/digital-shifted.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.9
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Design synthesis face combining SVG numerals, a seconds arc, and coloured glow layers. The green seconds arc glow and purple numeral glow DropShadow design elements are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2021
- **Qt6 import fix** — replace QtGraphicalEffects, drop version suffixes
- **Fix square geometry** — anchors.fill on root, maxSize property, ring Image, canvas, and inner Item made square with centerIn; canvas rotation pivot now matches arc draw centre on all screen shapes
- **Remove redundant z values** — five z properties removed, declaration order establishes the correct render stack
- **Consolidate font properties** — inline font assignments grouped into font blocks on all four Text items

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): circular ring and seconds arc centred correctly, numeral sizing, text positions, glow effects, AoD.