### PR TITLE
Refactor digital-terminal-haiku watchface for Qt6

### DIFF
--- a/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
+++ b/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
@@ -5,8 +5,8 @@
 // Cursor blinks at 1 Hz. Ambient-aware.
 // Font: VT323 (SIL OFL 1.1)
 
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
+import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root

--- a/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
+++ b/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
@@ -1,13 +1,9 @@
-/*
- * Terminal Haiku — AsteroidOS watchface
- *
- * Time rendered as if a terminal just printed `date +%T`.
- * Cursor blinks at 1 Hz. Ambient-aware.
- *
- * Font: VT323 (SIL OFL 1.1)
- */
 // SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: BSD-3-Clause
+// Terminal Haiku — AsteroidOS watchface
+// Time rendered as if a terminal just printed `date +%T`.
+// Cursor blinks at 1 Hz. Ambient-aware.
+// Font: VT323 (SIL OFL 1.1)
 
 import QtGraphicalEffects 1.15
 import QtQuick 2.15

--- a/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
+++ b/digital-terminal-haiku/usr/share/asteroid-launcher/watchfaces/digital-terminal-haiku.qml
@@ -15,6 +15,7 @@ Item {
     property string timeStr: ""
     property string secStr: ""
     property string dateStr: ""
+    readonly property real maxSize: Math.min(width, height)
     readonly property color termGreen: "#8affc1"
     readonly property color termDim: "#598a74"
 
@@ -48,7 +49,7 @@ Item {
         id: stack
 
         anchors.centerIn: parent
-        spacing: parent.height * 0.008
+        spacing: root.maxSize * 0.008
 
         layer {
             enabled: !displayAmbient
@@ -70,7 +71,7 @@ Item {
 
             font {
                 family: "VT323"
-                pixelSize: root.height * 0.085
+                pixelSize: root.maxSize * 0.085
             }
 
         }
@@ -87,8 +88,8 @@ Item {
 
                 font {
                     family: "VT323"
-                    pixelSize: root.height * 0.26
-                    letterSpacing: root.height * 0.006
+                    pixelSize: root.maxSize * 0.26
+                    letterSpacing: root.maxSize * 0.006
                 }
 
             }
@@ -103,7 +104,7 @@ Item {
 
                 font {
                     family: "VT323"
-                    pixelSize: root.height * 0.17
+                    pixelSize: root.maxSize * 0.17
                 }
 
             }
@@ -117,14 +118,14 @@ Item {
 
             font {
                 family: "VT323"
-                pixelSize: root.height * 0.085
+                pixelSize: root.maxSize * 0.085
             }
 
         }
 
         // Cursor block
         Row {
-            spacing: root.width * 0.012
+            spacing: root.maxSize * 0.012
             visible: !displayAmbient
 
             Text {
@@ -133,14 +134,14 @@ Item {
 
                 font {
                     family: "VT323"
-                    pixelSize: root.height * 0.085
+                    pixelSize: root.maxSize * 0.085
                 }
 
             }
 
             Rectangle {
-                width: root.width * 0.045
-                height: root.height * 0.08
+                width: root.maxSize * 0.045
+                height: root.maxSize * 0.08
                 color: root.cursorOn ? root.termGreen : "transparent"
                 anchors.verticalCenter: parent.verticalCenter
             }


### PR DESCRIPTION
## Summary

Recent minimal terminal aesthetic face. Mostly Qt6-ready — three small fixes needed.

## Commits

- **Move design comment below SPDX header** — convert block comment to // line format
- **Qt6 import fix** — replace QtGraphicalEffects, retain QtQuick-first ordering for Glow load order
- **Fix sizes for non-square screens** — maxSize property introduced, all font and cursor sizes switched from root.height/root.width to root.maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): font sizes proportional, cursor blink, Glow effect, AoD.