### PR TITLE
Refactor digital-thoreau-simplify watchface for Qt6

### DIFF
--- a/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
+++ b/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
@@ -1,20 +1,5 @@
-/*
- * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.12
 

--- a/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
+++ b/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.12
+import QtQuick
 
 Item {
     Rectangle {

--- a/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
+++ b/digital-thoreau-simplify/usr/share/asteroid-launcher/watchfaces/digital-thoreau-simplify.qml
@@ -4,152 +4,165 @@
 import QtQuick
 
 Item {
-    Rectangle {
-        id: logoArea
+    id: root
 
-        color: "transparent"
-        width: parent.width * 0.12
-        height: parent.height * 0.12
+    anchors.fill: parent
 
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: -parent.height * 0.272
-        }
+    Item {
+        id: faceBox
 
-        Image {
-            id: asteroidLogo
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
-            z: 1
-            visible: !displayAmbient
-            source: "../watchfaces-img/asteroid-logo.svg"
-            antialiasing: true
-            anchors.fill: parent
-            opacity: 0.7
+        Rectangle {
+            id: logoArea
 
-            Text {
-                id: asteroidSlogan
+            color: "transparent"
+            width: parent.width * 0.12
+            height: parent.height * 0.12
 
-                z: 2
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: -parent.height * 0.272
+            }
+
+            Image {
+                id: asteroidLogo
+
+                z: 1
                 visible: !displayAmbient
-                color: "white"
-                horizontalAlignment: Text.AlignHCenter
-                text: "<b>AsteroidOS</b><br>Free Your Wrist"
+                source: "../watchfaces-img/asteroid-logo.svg"
+                antialiasing: true
+                anchors.fill: parent
+                opacity: 0.7
 
-                font {
-                    family: "Raleway"
-                    pixelSize: parent.height * 0.31
-                }
+                Text {
+                    id: asteroidSlogan
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: -parent.height * 0.005
+                    z: 2
+                    visible: !displayAmbient
+                    color: "white"
+                    horizontalAlignment: Text.AlignHCenter
+                    text: "<b>AsteroidOS</b><br>Free Your Wrist"
+
+                    font {
+                        family: "Raleway"
+                        pixelSize: parent.height * 0.31
+                    }
+
+                    anchors {
+                        centerIn: parent
+                        verticalCenterOffset: -parent.height * 0.005
+                    }
+
                 }
 
             }
 
+            MouseArea {
+                anchors.fill: parent
+                onPressAndHold: asteroidLogo.visible = !asteroidLogo.visible
+            }
+
         }
 
-        MouseArea {
-            anchors.fill: parent
-            onPressAndHold: asteroidLogo.visible = !asteroidLogo.visible
+        Text {
+            id: datetext
+
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), "ddd dd")
+
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: parent.height * 0.25
+            }
+
+            font {
+                family: "Titillium"
+                weight: Font.Thin
+                pixelSize: parent.height * 0.06
+            }
+
         }
 
-    }
+        Text {
+            id: time
 
-    Text {
-        id: datetext
+            anchors.centerIn: parent
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), (use12H.value ? "hhmm ap" : "HHmm")).slice(0, 4)
 
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), "ddd dd")
+            font {
+                family: "Titillium"
+                weight: Font.Thin
+                pixelSize: parent.height * 0.3
+            }
 
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: parent.height * 0.25
         }
 
-        font {
-            family: "Titillium"
-            weight: Font.Thin
-            pixelSize: parent.height * 0.06
+        Text {
+            id: ampm
+
+            visible: use12H.value
+            color: "white"
+            text: wallClock.time.toLocaleString(Qt.locale(), "ap")
+
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: parent.height * 0.143
+            }
+
+            font {
+                family: "Titillium"
+                weight: Font.Bold
+                pixelSize: parent.height * 0.05
+            }
+
         }
 
-    }
+        Repeater {
+            id: secondMarks
 
-    Text {
-        id: time
-
-        anchors.centerIn: parent
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), (use12H.value ? "hhmm ap" : "HHmm")).slice(0, 4)
-
-        font {
-            family: "Titillium"
-            weight: Font.Thin
-            pixelSize: parent.height * 0.3
-        }
-
-    }
-
-    Text {
-        id: ampm
-
-        visible: use12H.value
-        color: "white"
-        text: wallClock.time.toLocaleString(Qt.locale(), "ap")
-
-        anchors {
-            centerIn: parent
-            verticalCenterOffset: parent.height * 0.143
-        }
-
-        font {
-            family: "Titillium"
-            weight: Font.Bold
-            pixelSize: parent.height * 0.05
-        }
-
-    }
-
-    Repeater {
-        id: secondMarks
-
-        model: 60
-
-        Rectangle {
-            id: second
-
-            visible: !displayAmbient
-            antialiasing: true
-            color: "transparent"
-            width: parent.width * 0.01
-            height: parent.height * 0.125
-            transform: [
-                Rotation {
-                    origin.x: second.width / 2
-                    origin.y: parent.height * 0.48
-                    angle: (index) * 360 / secondMarks.count
-                },
-                Translate {
-                    x: (parent.width - second.width) / 2
-                    y: parent.height / 2 - parent.height * 0.48
-                }
-            ]
+            model: 60
 
             Rectangle {
-                anchors.fill: parent
-                opacity: wallClock.time.getSeconds() == index ? 1 : 0
-                layer.enabled: wallClock.time.getSeconds() == index
+                id: second
+
+                visible: !displayAmbient
                 antialiasing: true
-
-                gradient: Gradient {
-                    GradientStop {
-                        position: 0
-                        color: "yellow"
+                color: "transparent"
+                width: parent.width * 0.01
+                height: parent.height * 0.125
+                transform: [
+                    Rotation {
+                        origin.x: second.width / 2
+                        origin.y: parent.height * 0.48
+                        angle: (index) * 360 / secondMarks.count
+                    },
+                    Translate {
+                        x: (parent.width - second.width) / 2
+                        y: parent.height / 2 - parent.height * 0.48
                     }
+                ]
 
-                    GradientStop {
-                        position: 1
-                        color: "darkorange"
+                Rectangle {
+                    anchors.fill: parent
+                    opacity: wallClock.time.getSeconds() == index ? 1 : 0
+                    layer.enabled: wallClock.time.getSeconds() == index
+                    antialiasing: true
+
+                    gradient: Gradient {
+                        GradientStop {
+                            position: 0
+                            color: "yellow"
+                        }
+
+                        GradientStop {
+                            position: 1
+                            color: "darkorange"
+                        }
+
                     }
 
                 }


### PR DESCRIPTION
## Summary

Elegant minimal face by beroset. Conservative pass — the dual-transform tick architecture and logo interaction are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures tick ring and font sizes resolve against the square face dimension on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): tick ring fits panel, active second gradient highlight, text sizes proportional, logo interaction, AoD.

## Notes

Please confirm the square geometry change matches your intent.