### PR TITLE
Refactor digital-weather-hrm-steps watchface for Qt6

### DIFF
--- a/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
+++ b/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
@@ -1,35 +1,9 @@
-/*
- * Copyright (C) 2025 - Jozef Mlich <github.com/jmlich>
- *               2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2025 Jozef Mlich <github.com/jmlich>
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import Nemo.Configuration 1.0
 import Nemo.Mce 1.0

--- a/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
+++ b/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
@@ -8,8 +8,8 @@
 import Nemo.Configuration
 import Nemo.Mce
 import Qt5Compat.GraphicalEffects
-import QtQuick
 import Qt5Compat.GraphicalEffects
+import QtQuick
 import QtQuick.Shapes
 import QtSensors
 import org.asteroid.controls
@@ -20,6 +20,7 @@ import "weathericons.js" as WeatherIcons
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
     property string imgPath: "../watchfaces-img/digital-weather-hrm-steps-"
     property int dayNb: 0
     // HRM initialisation. Needs to be declared global since hrmBox and hrmSwitch both need it.
@@ -55,7 +56,7 @@ Item {
         ctx.shadowColor = "black";
         ctx.shadowOffsetX = 0;
         ctx.shadowOffsetY = 0;
-        ctx.shadowBlur = root.height * 0.0125;
+        ctx.shadowBlur = root.maxSize * 0.0125;
     }
 
     anchors.fill: parent

--- a/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
+++ b/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
@@ -389,11 +389,6 @@ Item {
             anchors.fill: parent
             visible: nightstandMode.active
 
-            layer {
-                enabled: true
-                samples: 4
-            }
-
             Repeater {
                 id: segmentedArc
 

--- a/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
+++ b/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
@@ -413,17 +413,17 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: segment.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * (0.5 - segmentedArc.scalefactor)
+                        startX: segment.width / 2
+                        startY: segment.height * (0.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: segment.width / 2
+                            centerY: segment.height / 2
+                            radiusX: segmentedArc.scalefactor * segment.width
+                            radiusY: segmentedArc.scalefactor * segment.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true

--- a/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
+++ b/digital-weather-hrm-steps/usr/share/asteroid-launcher/watchfaces/digital-weather-hrm-steps.qml
@@ -5,15 +5,16 @@
 // SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
-import Nemo.Configuration 1.0
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
-import QtSensors 5.11
-import org.asteroid.controls 1.0
-import org.asteroid.sensorlogd 1.0
-import org.asteroid.utils 1.0
+import Nemo.Configuration
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Shapes
+import QtSensors
+import org.asteroid.controls
+import org.asteroid.sensorlogd
+import org.asteroid.utils
 import "weathericons.js" as WeatherIcons
 
 Item {


### PR DESCRIPTION
## Summary

Feature-rich face by Jozef Mlich with weather, HRM sensor, steps counter, and nightstand charging display. The face already uses a self-squaring inner Item for geometry — no faceBox guard needed. Conservative pass throughout.

## Commits

- **Convert SPDX header** — replace BSD block comment with SPDX BSD-3-Clause format, correct moWerk handle
- **Qt6 import fix** — replace QtGraphicalEffects, retain QtQuick-first ordering for ColorOverlay load order, drop all version suffixes
- **Remove nightstandMode layer block** — layer.enabled on nightstand item causes GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT on affected hardware
- **Fix ShapePath and PathAngleArc parent resolution** — replace parent with segment id throughout the nightstand charge arc
- **Fix prepareContext shadowBlur** — switch root.height to root.maxSize to match the square inner layout on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): Canvas text layout, HRM sensor toggle, weather display, steps counter, nightstand charge arc, AoD.

## Notes

Please confirm all changes match Jozef's intent, particularly the nightstand arc parent resolution fix and the square geometry approach. The midnight steps refresh fix by moWerk is preserved exactly.