### PR TITLE
Refactor greenium watchface for Qt6

### DIFF
--- a/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
+++ b/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
@@ -23,10 +23,6 @@ Item {
         width: Math.min(parent.width, parent.height)
         height: width
         anchors.centerIn: parent
-        Component.onCompleted: {
-            secondDisplay.second = wallClock.time.getSeconds();
-            secondDisplay.requestPaint();
-        }
 
         Canvas {
             anchors.fill: parent
@@ -85,9 +81,13 @@ Item {
             styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
             opacity: 0.98
             horizontalAlignment: Text.AlignHCenter
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: parent.height / 4
             text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.width * 0.15
+            }
 
             font {
                 pixelSize: parent.height * 0.3
@@ -106,9 +106,13 @@ Item {
             styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
             opacity: 0.98
             horizontalAlignment: Text.AlignHCenter
-            anchors.horizontalCenter: parent.horizontalCenter
-            y: parent.height / 1.95
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: parent.width * 0.11
+            }
 
             font {
                 pixelSize: parent.height * 0.3

--- a/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
+++ b/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     Component.onCompleted: {

--- a/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
+++ b/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.9
 

--- a/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
+++ b/greenium/usr/share/asteroid-launcher/watchfaces/greenium.qml
@@ -9,97 +9,113 @@
 import QtQuick
 
 Item {
+    id: root
+
+    anchors.fill: parent
     Component.onCompleted: {
         secondDisplay.second = wallClock.time.getSeconds();
         secondDisplay.requestPaint();
     }
 
-    Canvas {
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.lineWidth = parent.height / 48;
-            ctx.lineCap = "round";
-            ctx.strokeStyle = Qt.rgba(0.1, 0.1, 0.1, 0.95);
-            ctx.translate(parent.width / 2, parent.height / 2);
-            for (var i = 0; i < 60; i++) {
-                ctx.beginPath();
-                ctx.moveTo(0, height * 0.365);
-                ctx.lineTo(0, height * 0.405);
-                ctx.stroke();
-                ctx.rotate(Math.PI / 30);
+    Item {
+        id: faceBox
+
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
+        Component.onCompleted: {
+            secondDisplay.second = wallClock.time.getSeconds();
+            secondDisplay.requestPaint();
+        }
+
+        Canvas {
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.height / 48;
+                ctx.lineCap = "round";
+                ctx.strokeStyle = Qt.rgba(0.1, 0.1, 0.1, 0.95);
+                ctx.translate(parent.width / 2, parent.height / 2);
+                for (var i = 0; i < 60; i++) {
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.365);
+                    ctx.lineTo(0, height * 0.405);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
             }
         }
-    }
 
-    Canvas {
-        id: secondDisplay
+        Canvas {
+            id: secondDisplay
 
-        property int second: 0
+            property int second: 0
 
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.shadowColor = Qt.rgba(0.541, 0.796, 0.243, 0.85);
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 5;
-            ctx.lineWidth = parent.height / 58;
-            ctx.lineCap = "round";
-            ctx.strokeStyle = Qt.rgba(0.541, 0.796, 0.243, 1);
-            ctx.translate(parent.width / 2, parent.height / 2);
-            ctx.rotate(Math.PI);
-            for (var i = 0; i <= second; i++) {
-                ctx.beginPath();
-                ctx.moveTo(0, height * 0.367);
-                ctx.lineTo(0, height * 0.402);
-                ctx.stroke();
-                ctx.rotate(Math.PI / 30);
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0.541, 0.796, 0.243, 0.85);
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 5;
+                ctx.lineWidth = parent.height / 58;
+                ctx.lineCap = "round";
+                ctx.strokeStyle = Qt.rgba(0.541, 0.796, 0.243, 1);
+                ctx.translate(parent.width / 2, parent.height / 2);
+                ctx.rotate(Math.PI);
+                for (var i = 0; i <= second; i++) {
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.367);
+                    ctx.lineTo(0, height * 0.402);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
             }
         }
-    }
 
-    Text {
-        id: hourDisplay
+        Text {
+            id: hourDisplay
 
-        renderType: Text.NativeRendering
-        color: "white"
-        style: Text.Outline
-        styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
-        opacity: 0.98
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 4
-        text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+            renderType: Text.NativeRendering
+            color: "white"
+            style: Text.Outline
+            styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
+            opacity: 0.98
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 4
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
 
-        font {
-            pixelSize: parent.height * 0.3
-            family: "Titillium"
-            styleName: "Bold"
+            font {
+                pixelSize: parent.height * 0.3
+                family: "Titillium"
+                styleName: "Bold"
+            }
+
         }
 
-    }
+        Text {
+            id: minuteDisplay
 
-    Text {
-        id: minuteDisplay
+            renderType: Text.NativeRendering
+            color: "white"
+            style: Text.Outline
+            styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
+            opacity: 0.98
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 1.95
+            text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
-        renderType: Text.NativeRendering
-        color: "white"
-        style: Text.Outline
-        styleColor: Qt.rgba(0.1, 0.1, 0.1, 0.95)
-        opacity: 0.98
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 1.95
-        text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+            font {
+                pixelSize: parent.height * 0.3
+                family: "Titillium"
+                styleName: "Light"
+            }
 
-        font {
-            pixelSize: parent.height * 0.3
-            family: "Titillium"
-            styleName: "Light"
         }
 
     }


### PR DESCRIPTION
## Summary

An early 2018 face with a lasting user base. Green glowing second dot ring with big Titillium hour and minute. The Canvas glow effect is preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2018, split 2012 authors to individual lines
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures tick ring stays circular and text sizes proportional on non-square panels
- **Fix text anchoring and remove duplicate Component.onCompleted** — switch from absolute y positions to verticalCenter anchors with measured offsets to compensate for Qt6 asymmetric bounding box regression; remove redundant init block inside faceBox

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): circular tick ring, green second glow, hour and minute visually centred in ring, AoD.