### PR TITLE
Refactor logo-45degree watchface for Qt6

### DIFF
--- a/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
+++ b/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
@@ -12,86 +12,99 @@
 import QtQuick
 
 Item {
-    Image {
-        source: "../watchfaces-img/asteroid-logo.svg"
-        opacity: 0.75
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-        width: parent.width / 1.68
-        height: parent.height / 1.68
-    }
+    id: root
 
-    Text {
-        id: hourDisplay
+    anchors.fill: parent
 
-        property var hoffset: parent.width * 0.28
-        property var voffset: -parent.height * 0.03
-        property var rotH: (wallClock.time.getHours() - 3 + wallClock.time.getMinutes() / 60) / 12
+    Item {
+        id: faceBox
 
-        font.pixelSize: parent.height / 4
-        font.family: "sinner"
-        color: Qt.rgba(1, 1, 1, 0.8)
-        opacity: 0.95
-        style: Text.Outline
-        styleColor: Qt.rgba(0, 0, 0, 0.4)
-        x: parent.width / 3.8 - hoffset
-        y: parent.height / 3.8 - voffset
-        horizontalAlignment: Text.AlignHCenter
-        text: {
-            if (use12H.value)
-                wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
-            else
-                wallClock.time.toLocaleString(Qt.locale(), "HH");
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
+
+        Image {
+            source: "../watchfaces-img/asteroid-logo.svg"
+            opacity: 0.75
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            width: parent.width / 1.68
+            height: parent.height / 1.68
         }
 
-        transform: Rotation {
-            angle: -45
+        Text {
+            id: hourDisplay
+
+            property var hoffset: parent.width * 0.28
+            property var voffset: -parent.height * 0.03
+            property var rotH: (wallClock.time.getHours() - 3 + wallClock.time.getMinutes() / 60) / 12
+
+            font.pixelSize: parent.height / 4
+            font.family: "sinner"
+            color: Qt.rgba(1, 1, 1, 0.8)
+            opacity: 0.95
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, 0.4)
+            x: parent.width / 3.8 - hoffset
+            y: parent.height / 3.8 - voffset
+            horizontalAlignment: Text.AlignHCenter
+            text: {
+                if (use12H.value)
+                    wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
+                else
+                    wallClock.time.toLocaleString(Qt.locale(), "HH");
+            }
+
+            transform: Rotation {
+                angle: -45
+            }
+
         }
 
-    }
+        Text {
+            id: minuteDisplay
 
-    Text {
-        id: minuteDisplay
+            property var hoffset: parent.width * 0.035
+            property var voffset: parent.height * 0.28
 
-        property var hoffset: parent.width * 0.035
-        property var voffset: parent.height * 0.28
+            font.pixelSize: parent.height / 4
+            font.family: "sinner"
+            color: Qt.rgba(1, 1, 1, 0.8)
+            opacity: 0.95
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, 0.4)
+            x: parent.width / 1.35 - hoffset
+            y: parent.height / 3.8 - voffset
+            horizontalAlignment: Text.AlignHCenter
+            text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
-        font.pixelSize: parent.height / 4
-        font.family: "sinner"
-        color: Qt.rgba(1, 1, 1, 0.8)
-        opacity: 0.95
-        style: Text.Outline
-        styleColor: Qt.rgba(0, 0, 0, 0.4)
-        x: parent.width / 1.35 - hoffset
-        y: parent.height / 3.8 - voffset
-        horizontalAlignment: Text.AlignHCenter
-        text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+            transform: Rotation {
+                angle: +45
+            }
 
-        transform: Rotation {
-            angle: +45
         }
 
-    }
+        Text {
+            id: secondDisplay
 
-    Text {
-        id: secondDisplay
+            property var hoffset: parent.width * 0.28
+            property var voffset: -parent.height * 0.03
 
-        property var hoffset: parent.width * 0.28
-        property var voffset: -parent.height * 0.03
+            font.pixelSize: parent.height / 4
+            font.family: "sinner"
+            color: Qt.rgba(1, 1, 1, 0.8)
+            opacity: 0.95
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, 0.4)
+            x: parent.width / 1.35 - hoffset
+            y: parent.height / 1.35 - voffset
+            horizontalAlignment: Text.AlignHCenter
+            text: wallClock.time.toLocaleString(Qt.locale(), "ss")
 
-        font.pixelSize: parent.height / 4
-        font.family: "sinner"
-        color: Qt.rgba(1, 1, 1, 0.8)
-        opacity: 0.95
-        style: Text.Outline
-        styleColor: Qt.rgba(0, 0, 0, 0.4)
-        x: parent.width / 1.35 - hoffset
-        y: parent.height / 1.35 - voffset
-        horizontalAlignment: Text.AlignHCenter
-        text: wallClock.time.toLocaleString(Qt.locale(), "ss")
+            transform: Rotation {
+                angle: -45
+            }
 
-        transform: Rotation {
-            angle: -45
         }
 
     }

--- a/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
+++ b/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
@@ -9,7 +9,7 @@
 // rotate fonts to align them to other objects.
 // v2, changed font to Sinner for more edgy look fitting the logo.
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     Image {

--- a/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
+++ b/logo-45degree/usr/share/asteroid-launcher/watchfaces/logo-45degree.qml
@@ -1,30 +1,13 @@
-/*
- * Copyright (C) 2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-/*
- * Based on digital stock watchfaces, example of how to offset and
- * rotate fonts to align them to other objects.
- * v2, changed font to Sinner for more edgy look fitting the logo.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Based on digital stock watchfaces, example of how to offset and
+// rotate fonts to align them to other objects.
+// v2, changed font to Sinner for more edgy look fitting the logo.
 
 import QtQuick 2.1
 


### PR DESCRIPTION
## Summary

Transform example face showing ±45° rotated text around the AsteroidOS logo. Minimal changes — the rotation transforms and diagonal positioning math are preserved exactly.

## Commits

- **Convert SPDX header and design comment** — replace legacy block comments, update handle, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Add square geometry guard** — faceBox container ensures logo and text positions scale correctly on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): diagonal text positions, ±45° rotations, logo centred and square, AoD.