### PR TITLE
Refactor orbiting-asteroids watchface for Qt6

### DIFF
--- a/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
+++ b/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
@@ -11,6 +11,7 @@ import QtQuick
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
     property real radian: 0.0174533
     property string imgPath: "../watchfaces-img/orbiting-asteroids-"
 
@@ -43,6 +44,7 @@ Item {
         secondDisplay.y = h / 2 - sdH / 2 + Math.sin(rotSt * 2 * Math.PI) * sdH * 4.54;
     }
 
+    anchors.fill: parent
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         var minute = wallClock.time.getMinutes();
@@ -181,7 +183,7 @@ Item {
     Text {
         id: hourDisplay
 
-        font.pixelSize: parent.height / 4
+        font.pixelSize: root.maxSize / 4
         font.family: "OpenSans"
         font.styleName: "Bold"
         color: "white"
@@ -197,7 +199,7 @@ Item {
     Text {
         id: minuteDisplay
 
-        font.pixelSize: parent.height / 12.7
+        font.pixelSize: root.maxSize / 12.7
         font.family: "OpenSans"
         color: "white"
         style: Text.Outline
@@ -209,7 +211,7 @@ Item {
     Text {
         id: secondDisplay
 
-        font.pixelSize: parent.height / 14
+        font.pixelSize: root.maxSize / 14
         font.family: "OpenSans"
         color: "white"
         style: Text.Outline

--- a/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
+++ b/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 

--- a/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
+++ b/orbiting-asteroids/usr/share/asteroid-launcher/watchfaces/orbiting-asteroids.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Early AsteroidOS space theme face with orbital mechanics driving three asteroid images and comet trail Canvas arcs. The updatePositions() orbit algorithm and Canvas drawing logic are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate entries into correct 2018 moWerk line, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Fix geometry for non-square screens** — anchors.fill on root, maxSize property, font sizes switched to root.maxSize; orbital positioning math unchanged as it correctly uses root.width and root.height to find the panel centre

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): asteroid orbit positions, comet trail arcs, hour numeral centred, AoD.