### PR TITLE
Refactor prominent-seconds watchface for Qt6

### DIFF
--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 

--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Simple 2018 face with a filled second wedge arc and time centred in a circular overlay.

## Commits

- **Convert SPDX header** — replace legacy block comment, correct erroneous 2026 year to 2018, fix handle typo, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Remove z values and fix square geometry** — declaration order redundancy removed; faceBox container ensures arc, circle, and font sizes are square on all screen shapes; centre Rectangle fixed to always render as a circle

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): filled wedge arc geometry, circular overlay, time centred, AoD.