### PR TITLE
Refactor pulsedot watchface for Qt6

### DIFF
--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github/moWerk>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 

--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     id: root

--- a/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
+++ b/prominent-seconds/usr/share/asteroid-launcher/watchfaces/prominent-seconds.qml
@@ -11,58 +11,67 @@ import QtQuick
 Item {
     id: root
 
+    anchors.fill: parent
     Component.onCompleted: {
-        var second = wallClock.time.getSeconds();
-        secondCanvas.second = second;
+        secondCanvas.second = wallClock.time.getSeconds();
         secondCanvas.requestPaint();
     }
 
-    Canvas {
-        id: secondCanvas
+    Item {
+        id: faceBox
 
-        property int second: 0
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
 
-        z: 1
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            var rot = (second - 15) * 6;
-            ctx.reset();
-            ctx.beginPath();
-            ctx.lineWidth = parent.width / 42;
-            ctx.fillStyle = Qt.rgba(1, 0.549, 0.149, 0.7);
-            ctx.arc(parent.width / 2, parent.height / 2, width / 2.1, -90 * 0.0174533, rot * 0.0174533, false);
-            ctx.lineTo(parent.width / 2, parent.height / 2);
-            ctx.fill();
+        Canvas {
+            id: secondCanvas
+
+            property int second: 0
+
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                var rot = (second - 15) * 6;
+                ctx.reset();
+                ctx.beginPath();
+                ctx.lineWidth = parent.width / 42;
+                ctx.fillStyle = Qt.rgba(1, 0.549, 0.149, 0.7);
+                ctx.arc(parent.width / 2, parent.height / 2, width / 2.1, -90 * 0.0174533, rot * 0.0174533, false);
+                ctx.lineTo(parent.width / 2, parent.height / 2);
+                ctx.fill();
+            }
         }
-    }
 
-    Rectangle {
-        z: 2
-        x: root.width / 2 - width / 2
-        y: root.height / 2 - width / 2
-        color: Qt.rgba(0.184, 0.184, 0.184, 0.7)
-        width: parent.width * 0.465
-        height: parent.height * 0.465
-        radius: width * 0.5
-    }
+        Rectangle {
+            anchors.centerIn: parent
+            color: Qt.rgba(0.184, 0.184, 0.184, 0.7)
+            width: parent.width * 0.465
+            height: width
+            radius: width * 0.5
+        }
 
-    Text {
-        id: hourDisplay
+        Text {
+            id: hourDisplay
 
-        z: 3
-        font.pixelSize: parent.height * 0.16
-        font.family: "Raleway"
-        font.styleName: "Regular"
-        color: "white"
-        opacity: 1
-        style: Text.Outline
-        styleColor: "#80000000"
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-        text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "<b>hh</b> ap").slice(0, 9) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "<b>HH</b>") + wallClock.time.toLocaleString(Qt.locale(), ":mm")
+            color: "white"
+            opacity: 1
+            style: Text.Outline
+            styleColor: "#80000000"
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "<b>hh</b> ap").slice(0, 9) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "<b>HH</b>") + wallClock.time.toLocaleString(Qt.locale(), ":mm")
+
+            font {
+                pixelSize: parent.height * 0.16
+                family: "Raleway"
+                styleName: "Regular"
+            }
+
+        }
+
     }
 
     Connections {

--- a/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
+++ b/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
@@ -53,7 +53,6 @@ Item {
     Rectangle {
         id: circleTransBack
 
-        z: 0
         antialiasing: true
         visible: !displayAmbient
         x: root.width / 2 - width / 2
@@ -94,7 +93,6 @@ Item {
         property int minute: 0
         property var colorctx: Qt.rgba(0, 0, 0, 0.6)
 
-        z: 1
         visible: !displayAmbient
         anchors.fill: parent
         renderStrategy: Canvas.Cooperative
@@ -114,7 +112,6 @@ Item {
     Rectangle {
         id: circlePulse
 
-        z: 2
         visible: !displayAmbient
         antialiasing: true
         x: root.width / 2 - width / 2
@@ -169,7 +166,6 @@ Item {
 
         property int toggle: 1
 
-        z: 3
         antialiasing: true
         x: root.width / 2 - width / 2
         y: root.height / 2 - width / 2
@@ -227,7 +223,6 @@ Item {
         property real centerX: root.width / 2 - width / 2
         property real centerY: root.height / 2 - height / 2
 
-        z: 4
         antialiasing: true
         x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.3
         y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.3
@@ -283,7 +278,6 @@ Item {
         property real centerX: root.width / 2 - width / 2
         property real centerY: root.height / 2 - height / 2
 
-        z: 5
         font.pixelSize: root.height / 7.4
         font.family: "SourceSansPro"
         font.styleName: "Regular"
@@ -358,7 +352,6 @@ Item {
     Text {
         id: hourDisplay
 
-        z: 6
         font.pixelSize: root.height * 0.36
         font.family: "SourceSansPro"
         font.styleName: "Semibold"

--- a/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
+++ b/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
@@ -11,21 +11,23 @@ import QtQuick
 Item {
     id: root
 
+    property real maxSize: Math.min(width, height)
     property real radian: 0.01745
     property string currentColor: "black"
     property string userColor: ""
 
     function growShrink() {
-        circleDoubleClickCover.width = root.width * 0.8;
-        circleDoubleClickCover.height = root.width * 0.8;
+        circleDoubleClickCover.width = root.maxSize * 0.8;
+        circleDoubleClickCover.height = root.maxSize * 0.8;
         shrink.start();
     }
 
+    anchors.fill: parent
     Component.onCompleted: {
         var second = wallClock.time.getSeconds();
         var minute = wallClock.time.getMinutes();
-        circlePulse.width = (second % 2) ? root.width * 0.5 : root.width * 0.65;
-        circlePulse.height = (second % 2) ? root.height * 0.5 : root.height * 0.65;
+        circlePulse.width = (second % 2) ? root.maxSize * 0.5 : root.maxSize * 0.65;
+        circlePulse.height = (second % 2) ? root.maxSize * 0.5 : root.maxSize * 0.65;
         secondCanvas.second = second;
         secondCanvas.minute = minute;
         secondCanvas.requestPaint();
@@ -37,14 +39,14 @@ Item {
         NumberAnimation {
             target: circleDoubleClickCover
             property: "height"
-            to: root.width * 0.5
+            to: root.maxSize * 0.5
             duration: 300
         }
 
         NumberAnimation {
             target: circleDoubleClickCover
             property: "width"
-            to: root.width * 0.5
+            to: root.maxSize * 0.5
             duration: 300
         }
 
@@ -58,8 +60,8 @@ Item {
         x: root.width / 2 - width / 2
         y: root.height / 2 - width / 2
         color: Qt.rgba(1, 1, 1, 0.3)
-        width: root.width * 0.65
-        height: root.height * 0.65
+        width: root.maxSize * 0.65
+        height: root.maxSize * 0.65
         radius: width * 0.5
         state: currentColor
 
@@ -115,10 +117,10 @@ Item {
         visible: !displayAmbient
         antialiasing: true
         x: root.width / 2 - width / 2
-        y: root.height / 2 - width / 2
+        y: root.height / 2 - height / 2
         color: Qt.rgba(1, 1, 1, 1)
-        width: root.width * 0.5
-        height: root.height * 0.5
+        width: root.maxSize * 0.5
+        height: root.maxSize * 0.5
         radius: width * 0.5
         state: currentColor
 
@@ -170,8 +172,8 @@ Item {
         x: root.width / 2 - width / 2
         y: root.height / 2 - width / 2
         color: "white"
-        width: root.width * 0.5
-        height: root.height * 0.5
+        width: root.maxSize * 0.5
+        height: root.maxSize * 0.5
         radius: width * 0.5
         state: currentColor
 
@@ -227,8 +229,8 @@ Item {
         x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.3
         y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.3
         color: "white"
-        width: root.width * 0.24
-        height: root.height * 0.24
+        width: root.maxSize * 0.24
+        height: width
         radius: width * 0.5
         state: currentColor
 
@@ -278,7 +280,7 @@ Item {
         property real centerX: root.width / 2 - width / 2
         property real centerY: root.height / 2 - height / 2
 
-        font.pixelSize: root.height / 7.4
+        font.pixelSize: root.maxSize / 7.4
         font.family: "SourceSansPro"
         font.styleName: "Regular"
         color: "black"
@@ -352,10 +354,10 @@ Item {
     Text {
         id: hourDisplay
 
-        font.pixelSize: root.height * 0.36
+        font.pixelSize: root.maxSize * 0.36
         font.family: "SourceSansPro"
         font.styleName: "Semibold"
-        font.letterSpacing: -root.height * 0.026
+        font.letterSpacing: -root.maxSize * 0.026
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         color: "black"
@@ -441,8 +443,8 @@ Item {
         function onTimeChanged() {
             var second = wallClock.time.getSeconds();
             var minute = wallClock.time.getMinutes();
-            circlePulse.width = (second % 2) ? root.width * 0.5 : root.width * 0.65;
-            circlePulse.height = (second % 2) ? root.height * 0.5 : root.height * 0.65;
+            circlePulse.width = (second % 2) ? root.maxSize * 0.5 : root.maxSize * 0.65;
+            circlePulse.height = (second % 2) ? root.maxSize * 0.5 : root.maxSize * 0.65;
             if (secondCanvas.second !== second) {
                 secondCanvas.second = second;
                 secondCanvas.minute = minute;

--- a/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
+++ b/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2021 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2021 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.9
 

--- a/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
+++ b/pulsedot/usr/share/asteroid-launcher/watchfaces/pulsedot.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     id: root


### PR DESCRIPTION
## Summary

Pulsing circle face with orbiting minute dot, double-tap colour toggle, and ambient state preservation. Full polish pass — all animations, Behavior blocks, and the growShrink interaction are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate entries into correct 2021 moWerk line, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Remove redundant z values** — seven z properties removed, declaration order establishes the correct render stack
- **Fix square geometry** — maxSize property, all circle Rectangle items given height: width, font sizes and animation targets switched to root.maxSize to guarantee circular shapes and proportional text on non-square panels

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): circular pulse and minute dot, orbit positions, colour toggle, ambient state preservation, shrink animation, AoD.