### PR TITLE
Refactor rainbow-uprising watchface for Qt6

### DIFF
--- a/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
+++ b/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     Component.onCompleted: {

--- a/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
+++ b/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
@@ -9,6 +9,11 @@
 import QtQuick
 
 Item {
+    id: root
+
+    property real maxSize: Math.min(width, height)
+
+    anchors.fill: parent
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         var minute = wallClock.time.getMinutes();
@@ -23,7 +28,6 @@ Item {
 
     // Static rainbow background — plain Rectangles replace former Canvas.
     Rectangle {
-        z: 1
         x: parent.width / 6 * 0
         width: parent.width / 6
         height: parent.height
@@ -31,7 +35,6 @@ Item {
     }
 
     Rectangle {
-        z: 1
         x: parent.width / 6 * 1
         width: parent.width / 6
         height: parent.height
@@ -39,7 +42,6 @@ Item {
     }
 
     Rectangle {
-        z: 1
         x: parent.width / 6 * 2
         width: parent.width / 6
         height: parent.height
@@ -47,7 +49,6 @@ Item {
     }
 
     Rectangle {
-        z: 1
         x: parent.width / 6 * 3
         width: parent.width / 6
         height: parent.height
@@ -55,7 +56,6 @@ Item {
     }
 
     Rectangle {
-        z: 1
         x: parent.width / 6 * 4
         width: parent.width / 6
         height: parent.height
@@ -63,7 +63,6 @@ Item {
     }
 
     Rectangle {
-        z: 1
         x: parent.width / 6 * 5
         width: parent.width / 6
         height: parent.height
@@ -71,7 +70,6 @@ Item {
     }
 
     Rectangle {
-        z: 4
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter
         color: Qt.rgba(0, 0, 0, 0.7)
@@ -84,7 +82,6 @@ Item {
 
         property int hour: 0
 
-        z: 3
         anchors.fill: parent
         renderStrategy: Canvas.Cooperative
         onPaint: {
@@ -103,7 +100,6 @@ Item {
 
         property int minute: 0
 
-        z: 3
         anchors.fill: parent
         renderStrategy: Canvas.Cooperative
         onPaint: {
@@ -122,7 +118,6 @@ Item {
 
         property int second: 0
 
-        z: 3
         anchors.fill: parent
         renderStrategy: Canvas.Cooperative
         onPaint: {
@@ -139,52 +134,58 @@ Item {
     Text {
         id: hourDisplay
 
-        z: 6
         renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.25
-        font.family: "Titillium"
-        font.styleName: "Bold"
-        lineHeight: parent.height / 330
         color: Qt.rgba(1, 1, 1, 1)
         horizontalAlignment: Text.AlignHCenter
         anchors.top: parent.top
-        anchors.topMargin: parent.height * 0.395
+        anchors.topMargin: root.maxSize * 0.395
         x: parent.width / 6 - width / 2
         text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+
+        font {
+            pixelSize: root.maxSize * 0.25
+            family: "Titillium"
+            styleName: "Bold"
+        }
+
     }
 
     Text {
         id: minuteDisplay
 
-        z: 6
         renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.25
-        font.family: "Titillium"
-        font.styleName: "Regular"
-        lineHeight: parent.height / 330
         color: Qt.rgba(1, 1, 1, 1)
         horizontalAlignment: Text.AlignHCenter
         anchors.top: parent.top
-        anchors.topMargin: parent.height * 0.395
+        anchors.topMargin: root.maxSize * 0.395
         anchors.horizontalCenter: parent.horizontalCenter
         text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+        font {
+            pixelSize: root.maxSize * 0.25
+            family: "Titillium"
+            styleName: "Regular"
+        }
+
     }
 
     Text {
         id: secondDisplay
 
-        z: 6
         renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.25
-        font.family: "Titillium"
-        font.styleName: "Thin"
-        lineHeight: parent.height / 330
         color: Qt.rgba(1, 1, 1, 1)
         horizontalAlignment: Text.AlignHCenter
         anchors.top: parent.top
-        anchors.topMargin: parent.height * 0.395
+        anchors.topMargin: root.maxSize * 0.395
         x: parent.width / 6 * 5 - width / 2
         text: wallClock.time.toLocaleString(Qt.locale(), "ss")
+
+        font {
+            pixelSize: root.maxSize * 0.25
+            family: "Titillium"
+            styleName: "Thin"
+        }
+
     }
 
     Connections {

--- a/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
+++ b/rainbow-uprising/usr/share/asteroid-launcher/watchfaces/rainbow-uprising.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 


### PR DESCRIPTION
## Summary

Full-panel rainbow column overlay with rising bar indicators for hour, minute, and second. The rainbow columns and Canvas bars intentionally fill the full panel height — no faceBox guard applied.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate entries into correct 2018 moWerk line, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Add root id, fix text sizing, remove redundant z values** — anchors.fill and maxSize on root; font sizes and topMargin switched to maxSize; nine redundant z values removed while intentional z: 4 and z: 6 values preserved

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): rainbow columns fill panel, bars animate correctly, text centred in dark band, AoD.