### PR TITLE
Refactor sfos-style-one watchface for Qt6

### DIFF
--- a/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
+++ b/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
@@ -16,92 +16,105 @@
 import QtQuick
 
 Item {
+    id: root
+
+    property real maxSize: Math.min(width, height)
+
+    anchors.fill: parent
+
     Rectangle {
-        z: 0
         anchors.fill: parent
         color: Qt.rgba(0, 0, 0, 0.7)
     }
 
-    Text {
-        id: hourDisplay
+    Item {
+        id: faceBox
 
-        z: 1
-        color: Qt.rgba(0.592, 0.937, 0.937, 1)
-        text: wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
+        width: root.maxSize
+        height: root.maxSize
+        anchors.centerIn: parent
 
-        font {
-            pixelSize: parent.height * 0.33
-            family: "Source Sans Pro"
-            styleName: "ExtraLight"
+        Text {
+            id: hourDisplay
+
+            color: Qt.rgba(0.592, 0.937, 0.937, 1)
+            text: wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
+
+            font {
+                pixelSize: root.maxSize * 0.33
+                family: "Source Sans Pro"
+                styleName: "ExtraLight"
+            }
+
+            anchors {
+                topMargin: root.maxSize * 0.11
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+
         }
 
-        anchors {
-            topMargin: parent.height * 0.11
-            top: parent.top
-            horizontalCenter: parent.horizontalCenter
+        Text {
+            id: dowDisplay
+
+            color: Qt.rgba(0.592, 0.937, 0.937, 0.9)
+            horizontalAlignment: Text.AlignHCenter
+            text: Qt.formatDate(wallClock.time, "dddd")
+
+            font {
+                pixelSize: root.maxSize * 0.11
+                family: "Sail Sans Pro"
+                styleName: "ExtraLight"
+            }
+
+            anchors {
+                topMargin: -root.maxSize * 0.015
+                top: hourDisplay.bottom
+                left: hourDisplay.left
+            }
+
         }
 
-    }
+        Text {
+            id: dayDisplay
 
-    Text {
-        id: dowDisplay
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignHCenter
+            text: Qt.formatDate(wallClock.time, "dd")
 
-        color: Qt.rgba(0.592, 0.937, 0.937, 0.9)
-        horizontalAlignment: Text.AlignHCenter
-        text: Qt.formatDate(wallClock.time, "dddd")
+            font {
+                pixelSize: root.maxSize * 0.28
+                family: "Source Sans Pro"
+                styleName: "ExtraLight"
+            }
 
-        font {
-            pixelSize: parent.height * 0.11
-            family: "Sail Sans Pro"
-            styleName: "ExtraLight"
+            anchors {
+                topMargin: -root.maxSize * 0.075
+                top: hourDisplay.bottom
+                right: hourDisplay.right
+            }
+
         }
 
-        anchors {
-            topMargin: -parent.height * 0.015
-            top: hourDisplay.bottom
-            left: hourDisplay.left
-        }
+        Text {
+            id: monthDisplay
 
-    }
+            color: Qt.rgba(0.592, 0.937, 0.937, 0.6)
+            horizontalAlignment: Text.AlignHCenter
+            text: Qt.formatDate(wallClock.time, "MMMM")
 
-    Text {
-        id: dayDisplay
+            font {
+                pixelSize: root.maxSize * 0.1
+                family: "Sail Sans Pro"
+                styleName: "ExtraLight"
+            }
 
-        color: Qt.rgba(1, 1, 1, 1)
-        horizontalAlignment: Text.AlignHCenter
-        text: Qt.formatDate(wallClock.time, "dd")
+            anchors {
+                topMargin: -root.maxSize * 0.03
+                top: dowDisplay.bottom
+                left: dowDisplay.left
+            }
 
-        font {
-            pixelSize: parent.height * 0.28
-            family: "Source Sans Pro"
-            styleName: "ExtraLight"
-        }
-
-        anchors {
-            topMargin: -parent.height * 0.075
-            top: hourDisplay.bottom
-            right: hourDisplay.right
-        }
-
-    }
-
-    Text {
-        id: monthDisplay
-
-        color: Qt.rgba(0.592, 0.937, 0.937, 0.6)
-        horizontalAlignment: Text.AlignHCenter
-        text: Qt.formatDate(wallClock.time, "MMMM")
-
-        font {
-            pixelSize: parent.height * 0.1
-            family: "Sail Sans Pro"
-            styleName: "ExtraLight"
-        }
-
-        anchors {
-            topMargin: -parent.height * 0.03
-            top: dowDisplay.bottom
-            left: dowDisplay.left
         }
 
     }

--- a/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
+++ b/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
@@ -1,31 +1,17 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <mo@mowerk.net>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-/*
- * This watchface is a fan recreation of Jolla Oy's Sailfish Watch concept designs from 2016.
- * Visual design elements (e.g., hand styles, strokes, shadows, and layout) are derived from Jolla's intellectual property as shown at https://blog.jolla.com/watch/.
- * Used and distributed with explicit permission from Jolla Oy (granted by CEO Sami Pienimäki in 2026, with witnesses at FOSDEM).
- * Permission is for non-commercial, community-driven distribution within the AsteroidOS unofficial-watchfaces repository.
- */
+// SPDX-FileCopyrightText: 2026 Timo Könnecke <mo@mowerk.net>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// This watchface is a fan recreation of Jolla Oy's Sailfish Watch concept designs from 2016.
+// Visual design elements (e.g., hand styles, strokes, shadows, and layout) are derived from
+// Jolla's intellectual property as shown at https://blog.jolla.com/watch/.
+// Used and distributed with explicit permission from Jolla Oy (granted by CEO Sami Pienimäki
+// in 2026, with witnesses at FOSDEM).
+// Permission is for non-commercial, community-driven distribution within the AsteroidOS
+// unofficial-watchfaces repository.
 
 import QtQuick 2.9
 

--- a/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
+++ b/sfos-style-one/usr/share/asteroid-launcher/watchfaces/sfos-style-one.qml
@@ -13,7 +13,7 @@
 // Permission is for non-commercial, community-driven distribution within the AsteroidOS
 // unofficial-watchfaces repository.
 
-import QtQuick 2.9
+import QtQuick
 
 Item {
     Rectangle {


### PR DESCRIPTION
## Summary

Fan recreation of Jolla Oy's 2016 Sailfish Watch concept, distributed with explicit permission from CEO Sami Pienimäki (FOSDEM 2026). The permission notice is preserved verbatim in the file header.

## Commits

- **Convert SPDX header** — replace legacy block comment, split 2012 authors, convert Jolla permission notice to // line format below license
- **Qt6 import fix** — drop QtQuick version suffix
- **Remove z values and fix square geometry** — redundant z values removed; background fills full panel; text items in square faceBox; font sizes switched to root.maxSize

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): time and date text positions, full-panel background, AoD.