### PR TITLE
Refactor sporty-round watchface for Qt6

### DIFF
--- a/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
+++ b/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import QtQuick 2.1
+import QtQuick
 
 Item {
     Component.onCompleted: {

--- a/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
+++ b/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
@@ -1,26 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2018 - Timo Könnecke <el-t-mo@arcor.de>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2018 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.1
 

--- a/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
+++ b/sporty-round/usr/share/asteroid-launcher/watchfaces/sporty-round.qml
@@ -9,6 +9,9 @@
 import QtQuick
 
 Item {
+    id: root
+
+    anchors.fill: parent
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         var minute = wallClock.time.getMinutes();
@@ -23,245 +26,265 @@ Item {
         hourArc.requestPaint();
     }
 
-    Canvas {
-        z: 1
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.lineWidth = parent.height / 38;
-            ctx.strokeStyle = Qt.rgba(0.169, 0.169, 0.169, 0.85);
-            ctx.beginPath();
-            ctx.arc(width / 2, height / 2, height * 0.44, 0, 2 * Math.PI, false);
-            ctx.closePath();
-            ctx.stroke();
-        }
-    }
+    Item {
+        id: faceBox
 
-    Canvas {
-        z: 2
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.lineWidth = parent.height / 200;
-            ctx.strokeStyle = Qt.rgba(0.784, 0.784, 0.784, 0.5);
-            ctx.translate(parent.width / 2, parent.height / 2);
-            for (var i = 0; i < 60; i++) {
+        width: Math.min(parent.width, parent.height)
+        height: width
+        anchors.centerIn: parent
+
+        Canvas {
+            z: 1
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.height / 38;
+                ctx.strokeStyle = Qt.rgba(0.169, 0.169, 0.169, 0.85);
                 ctx.beginPath();
-                ctx.moveTo(0, height * 0.43);
-                ctx.lineTo(0, height * 0.475);
+                ctx.arc(width / 2, height / 2, height * 0.44, 0, 2 * Math.PI, false);
+                ctx.closePath();
                 ctx.stroke();
-                ctx.rotate(Math.PI / 30);
             }
         }
-    }
 
-    Canvas {
-        id: secondDisplay
-
-        z: 3
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            var s = wallClock.time.getSeconds();
-            ctx.reset();
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 4;
-            ctx.lineWidth = parent.height / 200;
-            ctx.translate(parent.width / 2, parent.height / 2);
-            ctx.rotate(Math.PI);
-            for (var i = 0; i <= s; i++) {
-                var alpha = s > 0 ? i / s : 0;
-                ctx.strokeStyle = Qt.rgba(0.361, 1, 0.824, alpha);
-                ctx.shadowColor = Qt.rgba(0.361, 1, 0.824, alpha);
-                ctx.beginPath();
-                ctx.moveTo(0, height * 0.43);
-                ctx.lineTo(0, height * 0.475);
-                ctx.stroke();
-                ctx.rotate(Math.PI / 30);
+        Canvas {
+            z: 2
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.height / 200;
+                ctx.strokeStyle = Qt.rgba(0.784, 0.784, 0.784, 0.5);
+                ctx.translate(parent.width / 2, parent.height / 2);
+                for (var i = 0; i < 60; i++) {
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.43);
+                    ctx.lineTo(0, height * 0.475);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
             }
         }
-    }
 
-    Canvas {
-        id: secondHand
+        Canvas {
+            id: secondDisplay
 
-        property int second: 0
-
-        z: 4
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.lineWidth = parent.height / 200;
-            ctx.strokeStyle = Qt.rgba(0.361, 1, 0.824, 1);
-            ctx.shadowColor = Qt.rgba(0.361, 1, 0.824, 0.9);
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 4;
-            var angle = (second - 15) / 60 * 2 * Math.PI;
-            ctx.beginPath();
-            ctx.moveTo(parent.width / 2 + Math.cos(angle) * width * 0.28, parent.height / 2 + Math.sin(angle) * width * 0.28);
-            ctx.lineTo(parent.width / 2 + Math.cos(angle) * width * 0.43, parent.height / 2 + Math.sin(angle) * width * 0.43);
-            ctx.stroke();
-        }
-    }
-
-    Canvas {
-        z: 3
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.lineWidth = parent.height / 32;
-            ctx.strokeStyle = Qt.rgba(0.384, 0.384, 0.384, 0.8);
-            ctx.translate(parent.width / 2, parent.height / 2);
-            for (var i = 0; i < 60; i++) {
-                ctx.beginPath();
-                ctx.moveTo(0, height * 0.355);
-                ctx.lineTo(0, height * 0.395);
-                ctx.stroke();
-                ctx.rotate(Math.PI / 30);
+            z: 3
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                var s = wallClock.time.getSeconds();
+                ctx.reset();
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 4;
+                ctx.lineWidth = parent.height / 200;
+                ctx.translate(parent.width / 2, parent.height / 2);
+                ctx.rotate(Math.PI);
+                for (var i = 0; i <= s; i++) {
+                    var alpha = s > 0 ? i / s : 0;
+                    ctx.strokeStyle = Qt.rgba(0.361, 1, 0.824, alpha);
+                    ctx.shadowColor = Qt.rgba(0.361, 1, 0.824, alpha);
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.43);
+                    ctx.lineTo(0, height * 0.475);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
             }
         }
-    }
 
-    Canvas {
-        id: minuteDisplay
+        Canvas {
+            id: secondHand
 
-        z: 6
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            var m = wallClock.time.getMinutes();
-            ctx.reset();
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 5;
-            ctx.lineWidth = parent.height / 34;
-            ctx.translate(parent.width / 2, parent.height / 2);
-            ctx.rotate(Math.PI);
-            for (var i = 0; i <= m; i++) {
-                var alpha = m > 0 ? i / m : 0;
-                ctx.strokeStyle = Qt.rgba(0.992, 0.988, 0.039, alpha);
-                ctx.shadowColor = Qt.rgba(0.992, 0.988, 0.039, alpha);
+            property int second: 0
+
+            z: 4
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.lineWidth = parent.height / 200;
+                ctx.strokeStyle = Qt.rgba(0.361, 1, 0.824, 1);
+                ctx.shadowColor = Qt.rgba(0.361, 1, 0.824, 0.9);
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 4;
+                var angle = (second - 15) / 60 * 2 * Math.PI;
                 ctx.beginPath();
-                ctx.moveTo(0, height * 0.36);
-                ctx.lineTo(0, height * 0.39);
+                ctx.moveTo(parent.width / 2 + Math.cos(angle) * width * 0.28, parent.height / 2 + Math.sin(angle) * width * 0.28);
+                ctx.lineTo(parent.width / 2 + Math.cos(angle) * width * 0.43, parent.height / 2 + Math.sin(angle) * width * 0.43);
                 ctx.stroke();
-                ctx.rotate(Math.PI / 30);
             }
         }
-    }
 
-    Canvas {
-        id: minuteHand
-
-        property int minute: 0
-
-        z: 5
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.reset();
-            ctx.lineWidth = parent.height / 100;
-            ctx.strokeStyle = Qt.rgba(0.992, 0.988, 0.039, 1);
-            ctx.shadowColor = Qt.rgba(0.992, 0.988, 0.039, 1);
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 5;
-            var angle = (minute - 15) / 60 * 2 * Math.PI;
-            ctx.beginPath();
-            ctx.moveTo(parent.width / 2 + Math.cos(angle) * width * 0.285, parent.height / 2 + Math.sin(angle) * width * 0.285);
-            ctx.lineTo(parent.width / 2 + Math.cos(angle) * width * 0.36, parent.height / 2 + Math.sin(angle) * width * 0.36);
-            ctx.stroke();
+        Canvas {
+            z: 3
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.height / 32;
+                ctx.strokeStyle = Qt.rgba(0.384, 0.384, 0.384, 0.8);
+                ctx.translate(parent.width / 2, parent.height / 2);
+                for (var i = 0; i < 60; i++) {
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.355);
+                    ctx.lineTo(0, height * 0.395);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
+            }
         }
-    }
 
-    Canvas {
-        id: hourArc
+        Canvas {
+            id: minuteDisplay
 
-        property int hour: 0
-
-        z: 1
-        anchors.fill: parent
-        renderStrategy: Canvas.Cooperative
-        onPaint: {
-            var ctx = getContext("2d");
-            var rot = 0.5 * (60 * (hour - 3) + wallClock.time.getMinutes());
-            ctx.reset();
-            ctx.shadowColor = Qt.rgba(0.996, 0, 0.031, 0.7);
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            ctx.shadowBlur = 4;
-            ctx.lineWidth = parent.height / 82;
-            ctx.lineCap = "round";
-            ctx.strokeStyle = Qt.rgba(0.996, 0, 0.031, 0.9);
-            ctx.beginPath();
-            ctx.arc(parent.width / 2, parent.height / 2, width * 0.32, 270 * 0.01745, rot * 0.01745, false);
-            ctx.stroke();
+            z: 6
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                var m = wallClock.time.getMinutes();
+                ctx.reset();
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 5;
+                ctx.lineWidth = parent.height / 34;
+                ctx.translate(parent.width / 2, parent.height / 2);
+                ctx.rotate(Math.PI);
+                for (var i = 0; i <= m; i++) {
+                    var alpha = m > 0 ? i / m : 0;
+                    ctx.strokeStyle = Qt.rgba(0.992, 0.988, 0.039, alpha);
+                    ctx.shadowColor = Qt.rgba(0.992, 0.988, 0.039, alpha);
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.36);
+                    ctx.lineTo(0, height * 0.39);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 30);
+                }
+            }
         }
-    }
 
-    Text {
-        id: hourDisplay
+        Canvas {
+            id: minuteHand
 
-        z: 6
-        renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.23
-        font.family: "SlimSans"
-        font.styleName: "Regular"
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.95
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-        text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "<b>hh</b> ap").slice(0, 9) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "<b>HH</b>") + wallClock.time.toLocaleString(Qt.locale(), ":mm")
-    }
+            property int minute: 0
 
-    Text {
-        id: dayofweekDisplay
+            z: 5
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.lineWidth = parent.height / 100;
+                ctx.strokeStyle = Qt.rgba(0.992, 0.988, 0.039, 1);
+                ctx.shadowColor = Qt.rgba(0.992, 0.988, 0.039, 1);
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 5;
+                var angle = (minute - 15) / 60 * 2 * Math.PI;
+                ctx.beginPath();
+                ctx.moveTo(parent.width / 2 + Math.cos(angle) * width * 0.285, parent.height / 2 + Math.sin(angle) * width * 0.285);
+                ctx.lineTo(parent.width / 2 + Math.cos(angle) * width * 0.36, parent.height / 2 + Math.sin(angle) * width * 0.36);
+                ctx.stroke();
+            }
+        }
 
-        z: 7
-        renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.065
-        font.family: "SlimSans"
-        font.styleName: "light"
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.9
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 1.45
-        text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
-    }
+        Canvas {
+            id: hourArc
 
-    Text {
-        id: dateDisplay
+            property int hour: 0
 
-        z: 8
-        renderType: Text.NativeRendering
-        font.pixelSize: parent.height * 0.065
-        font.family: "SlimSans"
-        font.styleName: "Regular"
-        lineHeight: parent.height * 0.0025
-        color: "white"
-        style: Text.Outline
-        styleColor: "#80000000"
-        opacity: 0.9
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: parent.height / 1.65
-        text: wallClock.time.toLocaleString(Qt.locale(), "dd MMMM yyyy")
+            z: 1
+            anchors.fill: parent
+            renderStrategy: Canvas.Cooperative
+            onPaint: {
+                var ctx = getContext("2d");
+                var rot = 0.5 * (60 * (hour - 3) + wallClock.time.getMinutes());
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0.996, 0, 0.031, 0.7);
+                ctx.shadowOffsetX = 0;
+                ctx.shadowOffsetY = 0;
+                ctx.shadowBlur = 4;
+                ctx.lineWidth = parent.height / 82;
+                ctx.lineCap = "round";
+                ctx.strokeStyle = Qt.rgba(0.996, 0, 0.031, 0.9);
+                ctx.beginPath();
+                ctx.arc(parent.width / 2, parent.height / 2, width * 0.32, 270 * 0.01745, rot * 0.01745, false);
+                ctx.stroke();
+            }
+        }
+
+        Text {
+            id: hourDisplay
+
+            z: 6
+            renderType: Text.NativeRendering
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.95
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "<b>hh</b> ap").slice(0, 9) + wallClock.time.toLocaleString(Qt.locale(), ":mm") : wallClock.time.toLocaleString(Qt.locale(), "<b>HH</b>") + wallClock.time.toLocaleString(Qt.locale(), ":mm")
+
+            font {
+                pixelSize: parent.height * 0.23
+                family: "SlimSans"
+                styleName: "Regular"
+            }
+
+        }
+
+        Text {
+            id: dayofweekDisplay
+
+            z: 7
+            renderType: Text.NativeRendering
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.9
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 1.45
+            text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
+
+            font {
+                pixelSize: parent.height * 0.065
+                family: "SlimSans"
+                styleName: "Light"
+            }
+
+        }
+
+        Text {
+            id: dateDisplay
+
+            z: 8
+            renderType: Text.NativeRendering
+            color: "white"
+            style: Text.Outline
+            styleColor: "#80000000"
+            opacity: 0.9
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: parent.height / 1.65
+            text: wallClock.time.toLocaleString(Qt.locale(), "dd MMMM yyyy")
+
+            font {
+                pixelSize: parent.height * 0.065
+                family: "SlimSans"
+                styleName: "Regular"
+            }
+
+        }
+
     }
 
     Connections {


### PR DESCRIPTION
## Summary

Neon ring face with glowing second, minute, and hour arc indicators. All intentional z layering is preserved — the z values establish a deliberate render stack across eight Canvas items.

## Commits

- **Convert SPDX header** — replace legacy block comment, merge duplicate entries into correct 2018 moWerk line, split 2012 authors
- **Qt6 import fix** — drop QtQuick version suffix
- **Fix square geometry and consolidate fonts** — faceBox container, font blocks, styleName capitalisation fix, drop sub-1.0 lineHeight

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): circular ring geometry, neon glow arcs and hand indicators, text positions, AoD.