### PR TITLE
Refactor words-worte-palabras-mots-opensans watchface for Qt6

### DIFF
--- a/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
+++ b/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
@@ -6,12 +6,10 @@
 // SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
-import Nemo.Mce 1.0
-import QtGraphicalEffects 1.15
-import QtQuick 2.15
-import QtQuick.Shapes 1.15
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import Nemo.Mce
+import QtQuick
+import QtQuick.Shapes
+import org.asteroid.controls
 
 Item {
     id: root

--- a/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
+++ b/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
@@ -277,17 +277,17 @@ Item {
                 ShapePath {
                     fillColor: "transparent"
                     strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                    strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                    strokeWidth: segment.height * segmentedArc.arcStrokeWidth
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
-                    startX: parent.width / 2
-                    startY: parent.height * (0.5 - segmentedArc.scalefactor)
+                    startX: segment.width / 2
+                    startY: segment.height * (0.5 - segmentedArc.scalefactor)
 
                     PathAngleArc {
-                        centerX: parent.width / 2
-                        centerY: parent.height / 2
-                        radiusX: segmentedArc.scalefactor * parent.width
-                        radiusY: segmentedArc.scalefactor * parent.height
+                        centerX: segment.width / 2
+                        centerY: segment.height / 2
+                        radiusX: segmentedArc.scalefactor * segment.width
+                        radiusY: segmentedArc.scalefactor * segment.height
                         startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
                         sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                         moveToStart: true

--- a/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
+++ b/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
@@ -1,36 +1,10 @@
-/*
- * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import Nemo.Mce 1.0
 import QtGraphicalEffects 1.15

--- a/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
+++ b/words-worte-palabras-mots-opensans/usr/share/asteroid-launcher/watchfaces/words-worte-palabras-mots-opensans.qml
@@ -22,7 +22,7 @@ Item {
         ctx.shadowColor = "black";
         ctx.shadowOffsetX = 0;
         ctx.shadowOffsetY = 0;
-        ctx.shadowBlur = parent.height * 0.0125;
+        ctx.shadowBlur = watchfaceRoot.height * 0.0125;
     }
 
     anchors.fill: parent
@@ -175,7 +175,6 @@ Item {
             style: Text.Outline
             styleColor: "#80000000"
             opacity: 0.9
-            font.pixelSize: parent.height * 0.07
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM")
 
             anchors {
@@ -183,6 +182,10 @@ Item {
                 top: timeDisplay.bottom
                 left: parent.left
                 right: parent.right
+            }
+
+            font {
+                pixelSize: parent.height * 0.07
             }
 
         }


### PR DESCRIPTION
## Summary

Multilingual word clock demoted from stock to community repo. The five language generation functions (English, Spanish, German, French, Danish) and the existing watchfaceRoot square guard are preserved exactly.

## Commits

- **Convert SPDX header** — replace BSD block comment with SPDX BSD-3-Clause format, correct erroneous 2026 year to 2018
- **Qt6 import fix** — drop version suffixes, remove unused QtGraphicalEffects and org.asteroid.utils imports
- **Remove nightstandMode layer block and fix ShapePath** — GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT fix; ShapePath and PathAngleArc parent references replaced with segment id
- **Fix shadowBlur and consolidate font** — prepareContext shadow scales to watchfaceRoot.height; dateDisplay font grouped into font block

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): word clock text in all available locales, nightstand charge arc, battery icon and percentage, AoD.