### PR TITLE
Refactor kitt watchface for Qt6

### DIFF
--- a/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
+++ b/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2016 Velox <github.com/velox>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import Nemo.Mce 1.0
-import QtQuick 2.9
-import QtSensors 5.11
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import Nemo.Mce
+import QtQuick
+import QtSensors
+import org.asteroid.controls
+import org.asteroid.utils
 
 Item {
     id: watchFace

--- a/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
+++ b/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2016 - Velox <github.com/velox>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2016 Velox <github.com/velox>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import Nemo.Mce 1.0
 import QtQuick 2.9

--- a/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
+++ b/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
@@ -8,9 +8,11 @@ import org.asteroid.controls
 import org.asteroid.utils
 
 Item {
-    id: watchFace
+    id: root
 
     property string imgPath: "../watchfaces-img/"
+
+    anchors.fill: parent
 
     FontLoader {
         id: localFont
@@ -30,13 +32,13 @@ Item {
     Item {
         id: lcdArea
 
-        height: parent.height * 0.26
+        height: parent.width * 0.26
         width: parent.width * 0.68
 
         anchors {
             horizontalCenter: parent.horizontalCenter
             top: parent.top
-            topMargin: parent.height * 0.22
+            topMargin: parent.width * 0.22
         }
 
         Text {

--- a/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
+++ b/kitt/usr/share/asteroid-launcher/watchfaces/kitt.qml
@@ -14,12 +14,6 @@ Item {
 
     anchors.fill: parent
 
-    FontLoader {
-        id: localFont
-
-        name: 'Digital-7 Mono'
-    }
-
     Image {
         id: backgroundImage
 
@@ -52,7 +46,7 @@ Item {
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM")
 
             font {
-                family: localFont.name
+                family: "Digital-7 Mono"
                 pixelSize: parent.width * 0.1
                 capitalization: Font.Capitalize
             }
@@ -90,7 +84,7 @@ Item {
                 text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh:mm ap").slice(0, 5) : wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
 
                 font {
-                    family: localFont.name
+                    family: "Digital-7 Mono"
                     pixelSize: parent.width * 0.35
                     capitalization: Font.Capitalize
                 }
@@ -112,7 +106,7 @@ Item {
                 }
 
                 font {
-                    family: localFont.name
+                    family: "Digital-7 Mono"
                     pixelSize: timeDisplay.font.pixelSize * 0.5
                     capitalization: Font.Capitalize
                 }


### PR DESCRIPTION
## Summary

KITT dashboard face by Velox (2016) with compass sensor, Bluetooth status, and battery indicator. Conservative pass — sensor logic, compass rotation, and Bluetooth opacity bindings are preserved exactly.

## Commits

- **Convert SPDX header** — replace legacy block comment with SPDX one-liner format
- **Qt6 import fix** — drop version suffixes, restore org.asteroid.utils which provides BluetoothStatus
- **Fix square geometry** — rename root id, add anchors.fill, switch lcdArea dimensions from parent.height to parent.width
- **Remove FontLoader and reference system font directly** — FontLoader.name is read-only in Qt6; Digital-7 Mono is installed system-wide and referenced by literal family name

## Testing

Built on 2.2 nightly Qt 6.11 (sturgeon 400px). Verified on beluga 41mm (320x360px): LCD area positioned correctly, Digital-7 Mono font renders, compass rotation, Bluetooth status, battery indicator, AoD.

## Notes

Please confirm the square geometry change matches Velox's original intent.