### PR TITLE
sfos-style-three: add missing shader source .frag for reference only

### DIFF
--- a/sfos-style-three/usr/share/asteroid-launcher/watchfaces/sfos-style-three.frag
+++ b/sfos-style-three/usr/share/asteroid-launcher/watchfaces/sfos-style-three.frag
@@ -1,0 +1,16 @@
+#version 440
+
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 fragColor;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+};
+
+layout(binding = 1) uniform sampler2D source;
+layout(binding = 2) uniform sampler2D maskSource;
+
+void main(void) {
+    fragColor = texture(source, qt_TexCoord0) * (1.0 - texture(maskSource, qt_TexCoord0).a) * qt_Opacity;
+}


### PR DESCRIPTION
As per discussion with Magnefire and Kido, the shader source .frag should be provided with the watchface source for reference and for the case a recompile is necessary.